### PR TITLE
Add amp thread reading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Features
 
 - Multi-agent thread resolution:
+  - <img src="https://ampcode.com/favicon.ico" alt="Amp logo" width="16" height="16" /> Amp
   - <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex
   - <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude
   - <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode
@@ -19,6 +20,21 @@ npx skills add Xuanwo/turl
 ```
 
 ## Agents
+
+### Amp
+
+- Supported URI:
+  - `amp://<thread_id>`
+- Thread id format:
+  - `T-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+- Resolution:
+  - `XDG_DATA_HOME/amp/threads/<thread_id>.json`
+  - fallback: `~/.local/share/amp/threads/<thread_id>.json`
+- Example:
+
+```bash
+turl amp://T-019c0797-c402-7389-bd80-d785c98df295
+```
 
 ### Codex
 

--- a/skills/turl/SKILL.md
+++ b/skills/turl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: turl
-description: Use the turl CLI to resolve Codex, Claude, or OpenCode thread URIs and print thread content in markdown or raw records.
+description: Use the turl CLI to resolve Amp, Codex, Claude, or OpenCode thread URIs and print thread content in markdown or raw records.
 ---
 
 # turl
@@ -18,7 +18,7 @@ turl --version
 
 ## When to Use
 
-- The user gives a `codex://...`, `codex://threads/...`, `claude://...`, or `opencode://...` URI.
+- The user gives an `amp://...`, `codex://...`, `codex://threads/...`, `claude://...`, or `opencode://...` URI.
 - The user asks to inspect, view, or fetch thread content.
 
 ## Input
@@ -26,6 +26,7 @@ turl --version
 - A thread URI in one of these forms:
   - `codex://<session_id>`
   - `codex://threads/<session_id>`
+  - `amp://<thread_id>`
   - `claude://<session_id>`
   - `opencode://<session_id>`
 
@@ -59,6 +60,12 @@ OpenCode thread example:
 
 ```bash
 turl opencode://ses_43a90e3adffejRgrTdlJa48CtE
+```
+
+Amp thread example:
+
+```bash
+turl amp://T-019c0797-c402-7389-bd80-d785c98df295
 ```
 
 ## Agent Behavior

--- a/turl-cli/src/main.rs
+++ b/turl-cli/src/main.rs
@@ -8,7 +8,7 @@ use turl_core::{
 #[derive(Debug, Parser)]
 #[command(name = "turl", version, about = "Resolve and read code-agent threads")]
 struct Cli {
-    /// Thread URI like codex://<session_id>, codex://threads/<session_id>, claude://<session_id>, or opencode://<session_id>
+    /// Thread URI like amp://<session_id>, codex://<session_id>, codex://threads/<session_id>, claude://<session_id>, or opencode://<session_id>
     uri: String,
 
     /// Output raw JSON instead of markdown

--- a/turl-cli/tests/cli.rs
+++ b/turl-cli/tests/cli.rs
@@ -5,6 +5,7 @@ use predicates::prelude::*;
 use tempfile::tempdir;
 
 const SESSION_ID: &str = "019c871c-b1f9-7f60-9c4f-87ed09f13592";
+const AMP_SESSION_ID: &str = "T-019c0797-c402-7389-bd80-d785c98df295";
 
 fn setup_codex_tree() -> tempfile::TempDir {
     let temp = tempdir().expect("tempdir");
@@ -21,12 +22,30 @@ fn setup_codex_tree() -> tempfile::TempDir {
     temp
 }
 
+fn setup_amp_tree() -> tempfile::TempDir {
+    let temp = tempdir().expect("tempdir");
+    let thread_path = temp
+        .path()
+        .join(format!("amp/threads/{AMP_SESSION_ID}.json"));
+    fs::create_dir_all(thread_path.parent().expect("parent")).expect("mkdir");
+    fs::write(
+        &thread_path,
+        r#"{"id":"T-019c0797-c402-7389-bd80-d785c98df295","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"analyze"},{"type":"text","text":"world"}]}]}"#,
+    )
+    .expect("write");
+    temp
+}
+
 fn codex_uri() -> String {
     format!("codex://{SESSION_ID}")
 }
 
 fn codex_deeplink_uri() -> String {
     format!("codex://threads/{SESSION_ID}")
+}
+
+fn amp_uri() -> String {
+    format!("amp://{AMP_SESSION_ID}")
 }
 
 #[test]
@@ -84,4 +103,37 @@ fn missing_thread_returns_non_zero() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("thread not found"));
+}
+
+#[test]
+fn amp_outputs_markdown() {
+    let temp = setup_amp_tree();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("turl"));
+    cmd.env("XDG_DATA_HOME", temp.path())
+        .env("CODEX_HOME", temp.path().join("missing-codex"))
+        .env("CLAUDE_CONFIG_DIR", temp.path().join("missing-claude"))
+        .arg(amp_uri())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("# Thread"))
+        .stdout(predicate::str::contains("## 1. User"))
+        .stdout(predicate::str::contains("hello"))
+        .stdout(predicate::str::contains("analyze"))
+        .stdout(predicate::str::contains("world"));
+}
+
+#[test]
+fn amp_raw_outputs_json() {
+    let temp = setup_amp_tree();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("turl"));
+    cmd.env("XDG_DATA_HOME", temp.path())
+        .env("CODEX_HOME", temp.path().join("missing-codex"))
+        .env("CLAUDE_CONFIG_DIR", temp.path().join("missing-claude"))
+        .arg(amp_uri())
+        .arg("--raw")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"messages\""));
 }

--- a/turl-core/src/model.rs
+++ b/turl-core/src/model.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderKind {
+    Amp,
     Codex,
     Claude,
     Opencode,
@@ -11,6 +12,7 @@ pub enum ProviderKind {
 impl fmt::Display for ProviderKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Amp => write!(f, "amp"),
             Self::Codex => write!(f, "codex"),
             Self::Claude => write!(f, "claude"),
             Self::Opencode => write!(f, "opencode"),

--- a/turl-core/src/provider/amp.rs
+++ b/turl-core/src/provider/amp.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+
+use crate::error::{Result, TurlError};
+use crate::model::{ProviderKind, ResolutionMeta, ResolvedThread};
+use crate::provider::Provider;
+
+#[derive(Debug, Clone)]
+pub struct AmpProvider {
+    root: PathBuf,
+}
+
+impl AmpProvider {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    fn threads_root(&self) -> PathBuf {
+        self.root.join("threads")
+    }
+}
+
+impl Provider for AmpProvider {
+    fn resolve(&self, session_id: &str) -> Result<ResolvedThread> {
+        let threads_root = self.threads_root();
+        let path = threads_root.join(format!("{session_id}.json"));
+
+        if !path.exists() {
+            return Err(TurlError::ThreadNotFound {
+                provider: ProviderKind::Amp.to_string(),
+                session_id: session_id.to_string(),
+                searched_roots: vec![threads_root],
+            });
+        }
+
+        Ok(ResolvedThread {
+            provider: ProviderKind::Amp,
+            session_id: session_id.to_string(),
+            path,
+            metadata: ResolutionMeta {
+                source: "amp:threads".to_string(),
+                candidate_count: 1,
+                warnings: Vec::new(),
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use crate::provider::Provider;
+    use crate::provider::amp::AmpProvider;
+
+    #[test]
+    fn resolves_from_threads_directory() {
+        let temp = tempdir().expect("tempdir");
+        let threads = temp.path().join("threads");
+        fs::create_dir_all(&threads).expect("mkdir");
+        let path = threads.join("T-019c0797-c402-7389-bd80-d785c98df295.json");
+        fs::write(&path, "{\"messages\":[]}").expect("write");
+
+        let provider = AmpProvider::new(temp.path());
+        let resolved = provider
+            .resolve("T-019c0797-c402-7389-bd80-d785c98df295")
+            .expect("resolve should succeed");
+        assert_eq!(resolved.path, path);
+        assert_eq!(resolved.metadata.source, "amp:threads");
+    }
+
+    #[test]
+    fn missing_thread_returns_not_found() {
+        let temp = tempdir().expect("tempdir");
+        let provider = AmpProvider::new(temp.path());
+        let err = provider
+            .resolve("T-019c0797-c402-7389-bd80-d785c98df295")
+            .expect_err("must fail");
+        assert!(format!("{err}").contains("thread not found"));
+    }
+}

--- a/turl-core/src/service.rs
+++ b/turl-core/src/service.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::error::{Result, TurlError};
 use crate::model::{ProviderKind, ResolvedThread};
+use crate::provider::amp::AmpProvider;
 use crate::provider::claude::ClaudeProvider;
 use crate::provider::codex::CodexProvider;
 use crate::provider::opencode::OpencodeProvider;
@@ -12,6 +13,7 @@ use crate::uri::ThreadUri;
 
 pub fn resolve_thread(uri: &ThreadUri, roots: &ProviderRoots) -> Result<ResolvedThread> {
     match uri.provider {
+        ProviderKind::Amp => AmpProvider::new(&roots.amp_root).resolve(&uri.session_id),
         ProviderKind::Codex => CodexProvider::new(&roots.codex_root).resolve(&uri.session_id),
         ProviderKind::Claude => ClaudeProvider::new(&roots.claude_root).resolve(&uri.session_id),
         ProviderKind::Opencode => {


### PR DESCRIPTION
## Summary
- add Amp provider support with `amp://<thread_id>` URI parsing and validation
- resolve Amp threads from `XDG_DATA_HOME/amp/threads/<id>.json` with `~/.local/share/amp` fallback
- add Amp markdown extraction for JSON thread files and keep raw output path working
- add core/cli tests for Amp flow and sync README + skill docs

## Testing
- cargo test
- cargo clippy --all-targets
