### PR TITLE
release: bump version to 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "turl-cli"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "turl-core"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "dirs",
  "once_cell",

--- a/turl-cli/Cargo.toml
+++ b/turl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turl-cli"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 
 [[bin]]

--- a/turl-core/Cargo.toml
+++ b/turl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turl-core"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Context: packaged release drift vs `main`

This PR is a **release-alignment** change.

`main` already contains Codex SQLite-index thread resolution logic (commit `4afa2ae`: "feat(codex): support sqlite thread index for thread lookup").

The previously published package (`xuanwo-turl==0.0.3`) was cut before that logic and therefore did not include the SQLite-index resolution behavior present on `main`.

## Problem statement

For Codex URIs, current `main` resolves with this priority:

1. `state_<version>.sqlite` / `state.sqlite` (`threads` table)
2. filesystem `sessions/`
3. archived SQLite index
4. filesystem `archived_sessions/`

Published `0.0.3` behaved differently in synthetic fixtures where an index entry exists:

- packaged binary selected filesystem rollout path
- current `main` binary selected indexed rollout path

This means published binaries can diverge from repository behavior for Codex thread lookup.

## Why this PR is version-only

No runtime logic change is introduced here. The required Codex resolver behavior already exists on `main`; this PR prepares the next package release so published artifacts match current repository behavior.

## Changes in this PR

- bump `turl-core` version: `0.0.3` -> `0.0.4`
- bump `turl-cli` version: `0.0.3` -> `0.0.4`
- refresh crate versions in `Cargo.lock` to `0.0.4`

Files changed:

- `turl-core/Cargo.toml`
- `turl-cli/Cargo.toml`
- `Cargo.lock`

## Validation performed

- `CARGO_BUILD_JOBS=1 cargo test -j1`
  - `turl-core`: 24 passed
  - `turl-cli` integration: 6 passed

## Note on local-only harness

A local Codex regression harness was intentionally kept in fork-only branch `fork/codex-local-regression` and is **not** part of this upstream release PR.

## Release note for maintainers

After merge, create and push upstream tag `v0.0.4` to trigger `.github/workflows/pypi-publish.yml` and publish binaries containing current Codex SQLite-index resolution behavior.
