### PR TITLE
feat: add Gemini thread support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
   - <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp
   - <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex
   - <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude
+  - <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini
   - <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode
-- Default output is markdown with user/assistant-focused content.
+- Default output is timeline markdown with user/assistant messages and compact markers.
 - `--raw` outputs raw thread records.
 - Automatically respects official environment variables and default local data roots for each supported agent.
 
@@ -71,8 +72,17 @@ turl claude://2823d1df-720a-4c31-ac55-ae8ba726721f
 turl opencode://ses_43a90e3adffejRgrTdlJa48CtE
 ```
 
-### Raw Output
+### Gemini
+
+- Supported URI:
+  - `gemini://<session_id>`
+- Session id format:
+  - `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+- Resolution:
+  - `GEMINI_CLI_HOME/.gemini/tmp/*/chats/session-*.json`
+  - fallback: `~/.gemini/tmp/*/chats/session-*.json`
+- Example:
 
 ```bash
-turl codex://019c871c-b1f9-7f60-9c4f-87ed09f13592 --raw
+turl gemini://29d207db-ca7e-40ba-87f7-e14c9de60613
 ```

--- a/skills/turl/SKILL.md
+++ b/skills/turl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: turl
-description: Use the turl CLI to resolve Amp, Codex, Claude, or OpenCode thread URIs and print thread content in markdown or raw records.
+description: Use the turl CLI to resolve Amp, Codex, Claude, Gemini, or OpenCode thread URIs and print thread content in markdown or raw records.
 ---
 
 # turl
@@ -18,7 +18,7 @@ turl --version
 
 ## When to Use
 
-- The user gives an `amp://...`, `codex://...`, `codex://threads/...`, `claude://...`, or `opencode://...` URI.
+- The user gives an `amp://...`, `codex://...`, `codex://threads/...`, `claude://...`, `gemini://...`, or `opencode://...` URI.
 - The user asks to inspect, view, or fetch thread content.
 
 ## Input
@@ -28,11 +28,12 @@ turl --version
   - `codex://threads/<session_id>`
   - `amp://<thread_id>`
   - `claude://<session_id>`
+  - `gemini://<session_id>`
   - `opencode://<session_id>`
 
 ## Commands
 
-Default output (filtered markdown with user/assistant messages):
+Default output (timeline markdown with user/assistant messages and compact markers):
 
 ```bash
 turl codex://019c871c-b1f9-7f60-9c4f-87ed09f13592
@@ -60,6 +61,12 @@ OpenCode thread example:
 
 ```bash
 turl opencode://ses_43a90e3adffejRgrTdlJa48CtE
+```
+
+Gemini thread example:
+
+```bash
+turl gemini://29d207db-ca7e-40ba-87f7-e14c9de60613
 ```
 
 Amp thread example:

--- a/turl-cli/src/main.rs
+++ b/turl-cli/src/main.rs
@@ -8,7 +8,7 @@ use turl_core::{
 #[derive(Debug, Parser)]
 #[command(name = "turl", version, about = "Resolve and read code-agent threads")]
 struct Cli {
-    /// Thread URI like amp://<session_id>, codex://<session_id>, codex://threads/<session_id>, claude://<session_id>, or opencode://<session_id>
+    /// Thread URI like amp://<session_id>, codex://<session_id>, codex://threads/<session_id>, claude://<session_id>, gemini://<session_id>, or opencode://<session_id>
     uri: String,
 
     /// Output raw JSON instead of markdown

--- a/turl-core/src/model.rs
+++ b/turl-core/src/model.rs
@@ -6,6 +6,7 @@ pub enum ProviderKind {
     Amp,
     Codex,
     Claude,
+    Gemini,
     Opencode,
 }
 
@@ -15,6 +16,7 @@ impl fmt::Display for ProviderKind {
             Self::Amp => write!(f, "amp"),
             Self::Codex => write!(f, "codex"),
             Self::Claude => write!(f, "claude"),
+            Self::Gemini => write!(f, "gemini"),
             Self::Opencode => write!(f, "opencode"),
         }
     }

--- a/turl-core/src/provider/gemini.rs
+++ b/turl-core/src/provider/gemini.rs
@@ -1,0 +1,234 @@
+use std::cmp::Reverse;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde_json::Value;
+use walkdir::WalkDir;
+
+use crate::error::{Result, TurlError};
+use crate::model::{ProviderKind, ResolutionMeta, ResolvedThread};
+use crate::provider::Provider;
+
+#[derive(Debug, Clone)]
+pub struct GeminiProvider {
+    root: PathBuf,
+}
+
+impl GeminiProvider {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    fn tmp_root(&self) -> PathBuf {
+        self.root.join("tmp")
+    }
+
+    fn is_session_file(path: &Path) -> bool {
+        let is_session_file = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("session-") && name.ends_with(".json"));
+
+        let is_chats_entry = path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == "chats");
+
+        is_session_file && is_chats_entry
+    }
+
+    fn has_session_id(path: &Path, session_id: &str) -> bool {
+        let Ok(raw) = fs::read_to_string(path) else {
+            return false;
+        };
+
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            return false;
+        };
+
+        value
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id.eq_ignore_ascii_case(session_id))
+    }
+
+    fn find_candidates(tmp_root: &Path, session_id: &str) -> Vec<PathBuf> {
+        if !tmp_root.exists() {
+            return Vec::new();
+        }
+
+        WalkDir::new(tmp_root)
+            .into_iter()
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| entry.into_path())
+            .filter(|path| Self::is_session_file(path))
+            .filter(|path| Self::has_session_id(path, session_id))
+            .collect()
+    }
+
+    fn choose_latest(paths: Vec<PathBuf>) -> Option<(PathBuf, usize)> {
+        if paths.is_empty() {
+            return None;
+        }
+
+        let mut scored = paths
+            .into_iter()
+            .map(|path| {
+                let modified = fs::metadata(&path)
+                    .and_then(|meta| meta.modified())
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                (path, modified)
+            })
+            .collect::<Vec<_>>();
+
+        scored.sort_by_key(|(_, modified)| Reverse(*modified));
+        let count = scored.len();
+        scored.into_iter().next().map(|(path, _)| (path, count))
+    }
+}
+
+impl Provider for GeminiProvider {
+    fn resolve(&self, session_id: &str) -> Result<ResolvedThread> {
+        let tmp_root = self.tmp_root();
+        let candidates = Self::find_candidates(&tmp_root, session_id);
+
+        if let Some((selected, count)) = Self::choose_latest(candidates) {
+            let mut metadata = ResolutionMeta {
+                source: "gemini:chats".to_string(),
+                candidate_count: count,
+                warnings: Vec::new(),
+            };
+
+            if count > 1 {
+                metadata.warnings.push(format!(
+                    "multiple matches found ({count}) for session_id={session_id}; selected latest: {}",
+                    selected.display()
+                ));
+            }
+
+            return Ok(ResolvedThread {
+                provider: ProviderKind::Gemini,
+                session_id: session_id.to_string(),
+                path: selected,
+                metadata,
+            });
+        }
+
+        Err(TurlError::ThreadNotFound {
+            provider: ProviderKind::Gemini.to_string(),
+            session_id: session_id.to_string(),
+            searched_roots: vec![tmp_root],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::thread;
+    use std::time::Duration;
+
+    use tempfile::tempdir;
+
+    use crate::provider::Provider;
+    use crate::provider::gemini::GeminiProvider;
+
+    fn write_session(
+        root: &Path,
+        project_hash: &str,
+        file_name: &str,
+        session_id: &str,
+        user_text: &str,
+    ) -> PathBuf {
+        let path = root
+            .join("tmp")
+            .join(project_hash)
+            .join("chats")
+            .join(file_name);
+        fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+
+        let content = format!(
+            r#"{{
+  "sessionId": "{session_id}",
+  "projectHash": "{project_hash}",
+  "startTime": "2026-01-08T11:55:12.379Z",
+  "lastUpdated": "2026-01-08T12:31:14.881Z",
+  "messages": [
+    {{ "type": "user", "content": "{user_text}" }},
+    {{ "type": "gemini", "content": "done" }}
+  ]
+}}"#,
+        );
+        fs::write(&path, content).expect("write");
+        path
+    }
+
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn resolves_from_gemini_tmp_chats() {
+        let temp = tempdir().expect("tempdir");
+        let path = write_session(
+            temp.path(),
+            "0c0d7b04c22749f3687ea60b66949fd32bcea2551d4349bf72346a9ccc9a9ba4",
+            "session-2026-01-08T11-55-29-29d207db.json",
+            "29d207db-ca7e-40ba-87f7-e14c9de60613",
+            "hello",
+        );
+
+        let provider = GeminiProvider::new(temp.path());
+        let resolved = provider
+            .resolve("29d207db-ca7e-40ba-87f7-e14c9de60613")
+            .expect("resolve should succeed");
+        assert_eq!(resolved.path, path);
+        assert_eq!(resolved.metadata.source, "gemini:chats");
+    }
+
+    #[test]
+    fn selects_latest_when_multiple_matches_exist() {
+        let temp = tempdir().expect("tempdir");
+        let session_id = "29d207db-ca7e-40ba-87f7-e14c9de60613";
+
+        let first = write_session(
+            temp.path(),
+            "hash-a",
+            "session-2026-01-08T11-55-29-29d207db.json",
+            session_id,
+            "first",
+        );
+
+        thread::sleep(Duration::from_millis(15));
+
+        let second = write_session(
+            temp.path(),
+            "hash-b",
+            "session-2026-01-08T12-00-00-29d207db.json",
+            session_id,
+            "second",
+        );
+
+        let provider = GeminiProvider::new(temp.path());
+        let resolved = provider
+            .resolve(session_id)
+            .expect("resolve should succeed");
+        assert_eq!(resolved.path, second);
+        assert_eq!(resolved.metadata.candidate_count, 2);
+        assert_eq!(resolved.metadata.warnings.len(), 1);
+        assert!(resolved.metadata.warnings[0].contains("multiple matches"));
+
+        assert!(first.exists());
+    }
+
+    #[test]
+    fn missing_thread_returns_not_found() {
+        let temp = tempdir().expect("tempdir");
+        let provider = GeminiProvider::new(temp.path());
+        let err = provider
+            .resolve("29d207db-ca7e-40ba-87f7-e14c9de60613")
+            .expect_err("must fail");
+        assert!(format!("{err}").contains("thread not found"));
+    }
+}

--- a/turl-core/src/provider/mod.rs
+++ b/turl-core/src/provider/mod.rs
@@ -9,6 +9,7 @@ use crate::model::ResolvedThread;
 pub mod amp;
 pub mod claude;
 pub mod codex;
+pub mod gemini;
 pub mod opencode;
 
 pub trait Provider {
@@ -20,6 +21,7 @@ pub struct ProviderRoots {
     pub amp_root: PathBuf,
     pub codex_root: PathBuf,
     pub claude_root: PathBuf,
+    pub gemini_root: PathBuf,
     pub opencode_root: PathBuf,
 }
 
@@ -51,6 +53,14 @@ impl ProviderRoots {
             .unwrap_or_else(|| home.join(".claude"));
 
         // Precedence:
+        // 1) GEMINI_CLI_HOME/.gemini (official Gemini CLI home env)
+        // 2) ~/.gemini (Gemini default)
+        let gemini_root = env::var_os("GEMINI_CLI_HOME")
+            .map(PathBuf::from)
+            .map(|path| path.join(".gemini"))
+            .unwrap_or_else(|| home.join(".gemini"));
+
+        // Precedence:
         // 1) XDG_DATA_HOME/opencode
         // 2) ~/.local/share/opencode
         let opencode_root = env::var_os("XDG_DATA_HOME")
@@ -63,6 +73,7 @@ impl ProviderRoots {
             amp_root,
             codex_root,
             claude_root,
+            gemini_root,
             opencode_root,
         })
     }

--- a/turl-core/src/render.rs
+++ b/turl-core/src/render.rs
@@ -14,28 +14,43 @@ const TOOL_TYPES: &[&str] = &[
     "function_result",
     "function_response",
 ];
+const COMPACT_PLACEHOLDER: &str = "Context was compacted.";
+
+enum TimelineEntry {
+    Message(ThreadMessage),
+    Compact { summary: Option<String> },
+}
 
 pub fn render_markdown(uri: &ThreadUri, source_path: &Path, raw_jsonl: &str) -> Result<String> {
-    let messages = extract_messages(uri.provider, source_path, raw_jsonl)?;
+    let entries = extract_timeline_entries(uri.provider, source_path, raw_jsonl)?;
 
     let mut output = String::new();
     output.push_str("# Thread\n\n");
     output.push_str(&format!("- URI: `{}`\n", uri.as_string()));
     output.push_str(&format!("- Source: `{}`\n\n", source_path.display()));
 
-    if messages.is_empty() {
-        output.push_str("_No user/assistant messages found._\n");
+    if entries.is_empty() {
+        output.push_str("_No user/assistant messages or compact events found._\n");
         return Ok(output);
     }
 
-    for (idx, message) in messages.iter().enumerate() {
-        let title = match message.role {
-            MessageRole::User => "User",
-            MessageRole::Assistant => "Assistant",
+    for (idx, entry) in entries.iter().enumerate() {
+        let title = match entry {
+            TimelineEntry::Message(message) => match message.role {
+                MessageRole::User => "User",
+                MessageRole::Assistant => "Assistant",
+            },
+            TimelineEntry::Compact { .. } => "Context Compacted",
         };
 
         output.push_str(&format!("## {}. {}\n\n", idx + 1, title));
-        output.push_str(message.text.trim());
+        match entry {
+            TimelineEntry::Message(message) => output.push_str(message.text.trim()),
+            TimelineEntry::Compact { summary } => {
+                let summary = summary.as_deref().unwrap_or(COMPACT_PLACEHOLDER);
+                output.push_str(summary.trim());
+            }
+        }
         output.push_str("\n\n");
     }
 
@@ -47,11 +62,30 @@ pub fn extract_messages(
     path: &Path,
     raw_jsonl: &str,
 ) -> Result<Vec<ThreadMessage>> {
+    Ok(extract_timeline_entries(provider, path, raw_jsonl)?
+        .into_iter()
+        .filter_map(|entry| match entry {
+            TimelineEntry::Message(message) => Some(message),
+            TimelineEntry::Compact { .. } => None,
+        })
+        .collect())
+}
+
+fn extract_timeline_entries(
+    provider: ProviderKind,
+    path: &Path,
+    raw_jsonl: &str,
+) -> Result<Vec<TimelineEntry>> {
     if provider == ProviderKind::Amp {
-        return extract_amp_messages(path, raw_jsonl);
+        return Ok(messages_to_entries(extract_amp_messages(path, raw_jsonl)?));
+    }
+    if provider == ProviderKind::Gemini {
+        return Ok(messages_to_entries(extract_gemini_messages(
+            path, raw_jsonl,
+        )?));
     }
 
-    let mut messages = Vec::new();
+    let mut entries = Vec::new();
 
     for (line_idx, line) in raw_jsonl.lines().enumerate() {
         let line_no = line_idx + 1;
@@ -70,17 +104,22 @@ pub fn extract_messages(
 
         let extracted = match provider {
             ProviderKind::Amp => None,
-            ProviderKind::Codex => extract_codex_message(&value),
-            ProviderKind::Claude => extract_claude_message(&value),
-            ProviderKind::Opencode => extract_opencode_message(&value),
+            ProviderKind::Codex => extract_codex_entry(&value),
+            ProviderKind::Claude => extract_claude_entry(&value),
+            ProviderKind::Gemini => None,
+            ProviderKind::Opencode => extract_opencode_message(&value).map(TimelineEntry::Message),
         };
 
-        if let Some(message) = extracted {
-            messages.push(message);
+        if let Some(entry) = extracted {
+            entries.push(entry);
         }
     }
 
-    Ok(messages)
+    Ok(entries)
+}
+
+fn messages_to_entries(messages: Vec<ThreadMessage>) -> Vec<TimelineEntry> {
+    messages.into_iter().map(TimelineEntry::Message).collect()
 }
 
 fn extract_amp_messages(path: &Path, raw_json: &str) -> Result<Vec<ThreadMessage>> {
@@ -107,6 +146,46 @@ fn extract_amp_messages(path: &Path, raw_json: &str) -> Result<Vec<ThreadMessage
         };
 
         let text = extract_amp_text(message.get("content"));
+        if text.trim().is_empty() {
+            continue;
+        }
+
+        messages.push(ThreadMessage { role, text });
+    }
+
+    Ok(messages)
+}
+
+fn extract_gemini_messages(path: &Path, raw_json: &str) -> Result<Vec<ThreadMessage>> {
+    let value =
+        serde_json::from_str::<Value>(raw_json).map_err(|source| TurlError::InvalidJsonLine {
+            path: path.to_path_buf(),
+            line: 1,
+            source,
+        })?;
+
+    let mut messages = Vec::new();
+    for message in value
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let Some(role) = message
+            .get("type")
+            .and_then(Value::as_str)
+            .and_then(parse_gemini_role)
+        else {
+            continue;
+        };
+
+        let text = extract_text(message.get("displayContent"));
+        let text = if text.trim().is_empty() {
+            extract_text(message.get("content"))
+        } else {
+            text
+        };
+
         if text.trim().is_empty() {
             continue;
         }
@@ -164,6 +243,33 @@ fn extract_codex_message(value: &Value) -> Option<ThreadMessage> {
     None
 }
 
+fn extract_codex_entry(value: &Value) -> Option<TimelineEntry> {
+    if let Some(message) = extract_codex_message(value) {
+        return Some(TimelineEntry::Message(message));
+    }
+
+    if is_codex_compact_event(value) {
+        return Some(TimelineEntry::Compact { summary: None });
+    }
+
+    None
+}
+
+fn is_codex_compact_event(value: &Value) -> bool {
+    let record_type = value.get("type").and_then(Value::as_str);
+
+    if record_type == Some("compacted") {
+        return true;
+    }
+
+    record_type == Some("event_msg")
+        && value
+            .get("payload")
+            .and_then(|payload| payload.get("type"))
+            .and_then(Value::as_str)
+            .is_some_and(|payload_type| payload_type == "context_compacted")
+}
+
 fn extract_claude_message(value: &Value) -> Option<ThreadMessage> {
     let record_type = value.get("type").and_then(Value::as_str)?;
     if record_type != "user" && record_type != "assistant" {
@@ -183,6 +289,32 @@ fn extract_claude_message(value: &Value) -> Option<ThreadMessage> {
     }
 
     Some(ThreadMessage { role, text })
+}
+
+fn extract_claude_entry(value: &Value) -> Option<TimelineEntry> {
+    if is_claude_compact_boundary(value) {
+        return Some(TimelineEntry::Compact { summary: None });
+    }
+
+    if is_claude_compact_summary(value) {
+        let summary = extract_claude_message(value).map(|message| message.text);
+        return Some(TimelineEntry::Compact { summary });
+    }
+
+    extract_claude_message(value).map(TimelineEntry::Message)
+}
+
+fn is_claude_compact_boundary(value: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("system")
+        && value.get("subtype").and_then(Value::as_str) == Some("compact_boundary")
+}
+
+fn is_claude_compact_summary(value: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("user")
+        && value
+            .get("isCompactSummary")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
 }
 
 fn extract_opencode_message(value: &Value) -> Option<ThreadMessage> {
@@ -268,6 +400,14 @@ fn parse_role(role: &str) -> Option<MessageRole> {
     }
 }
 
+fn parse_gemini_role(role: &str) -> Option<MessageRole> {
+    match role {
+        "user" => Some(MessageRole::User),
+        "gemini" => Some(MessageRole::Assistant),
+        _ => None,
+    }
+}
+
 fn extract_text(content: Option<&Value>) -> String {
     let Some(content) = content else {
         return String::new();
@@ -284,6 +424,13 @@ fn extract_text(content: Option<&Value>) -> String {
     let mut chunks = Vec::new();
 
     for item in items {
+        if let Some(text) = item.as_str()
+            && !text.trim().is_empty()
+        {
+            chunks.push(text.trim().to_string());
+            continue;
+        }
+
         if let Some(item_type) = item.get("type").and_then(Value::as_str)
             && TOOL_TYPES.contains(&item_type)
         {
@@ -319,7 +466,8 @@ mod tests {
     use std::path::Path;
 
     use crate::model::ProviderKind;
-    use crate::render::extract_messages;
+    use crate::render::{extract_messages, render_markdown};
+    use crate::uri::ThreadUri;
 
     #[test]
     fn codex_filters_function_calls() {
@@ -367,5 +515,48 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].text, "hello");
         assert_eq!(messages[1].text, "step by step\n\ndone");
+    }
+
+    #[test]
+    fn gemini_extracts_user_and_assistant_messages() {
+        let raw = r#"{"sessionId":"29d207db-ca7e-40ba-87f7-e14c9de60613","messages":[{"type":"info","content":"ignored"},{"type":"user","content":"hello"},{"type":"gemini","content":"world"},{"type":"gemini","content":[{"type":"thinking","text":"step by step"},{"type":"tool_call","name":"list_directory"},{"type":"text","text":"done"}]}]}"#;
+
+        let messages =
+            extract_messages(ProviderKind::Gemini, Path::new("/tmp/mock"), raw).expect("extract");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].text, "hello");
+        assert_eq!(messages[1].text, "world");
+        assert_eq!(messages[2].text, "step by step\n\ndone");
+    }
+
+    #[test]
+    fn codex_renders_compact_events_in_timeline() {
+        let raw = r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}
+{"type":"event_msg","payload":{"type":"context_compacted"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"world"}]}}"#;
+
+        let uri =
+            ThreadUri::parse("codex://019c871c-b1f9-7f60-9c4f-87ed09f13592").expect("parse uri");
+        let output = render_markdown(&uri, Path::new("/tmp/mock"), raw).expect("render");
+
+        assert!(output.contains("## 1. User"));
+        assert!(output.contains("## 2. Context Compacted"));
+        assert!(output.contains("Context was compacted."));
+        assert!(output.contains("## 3. Assistant"));
+    }
+
+    #[test]
+    fn claude_compact_summary_renders_as_compact_entry() {
+        let raw = r#"{"type":"user","isCompactSummary":true,"message":{"role":"user","content":[{"type":"text","text":"Summary: old conversation"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"New answer"}]}}"#;
+
+        let uri =
+            ThreadUri::parse("claude://2823d1df-720a-4c31-ac55-ae8ba726721f").expect("parse uri");
+        let output = render_markdown(&uri, Path::new("/tmp/mock"), raw).expect("render");
+
+        assert!(output.contains("## 1. Context Compacted"));
+        assert!(output.contains("Summary: old conversation"));
+        assert!(!output.contains("## 1. User"));
+        assert!(output.contains("## 2. Assistant"));
     }
 }

--- a/turl-core/src/service.rs
+++ b/turl-core/src/service.rs
@@ -6,6 +6,7 @@ use crate::model::{ProviderKind, ResolvedThread};
 use crate::provider::amp::AmpProvider;
 use crate::provider::claude::ClaudeProvider;
 use crate::provider::codex::CodexProvider;
+use crate::provider::gemini::GeminiProvider;
 use crate::provider::opencode::OpencodeProvider;
 use crate::provider::{Provider, ProviderRoots};
 use crate::render;
@@ -16,6 +17,7 @@ pub fn resolve_thread(uri: &ThreadUri, roots: &ProviderRoots) -> Result<Resolved
         ProviderKind::Amp => AmpProvider::new(&roots.amp_root).resolve(&uri.session_id),
         ProviderKind::Codex => CodexProvider::new(&roots.codex_root).resolve(&uri.session_id),
         ProviderKind::Claude => ClaudeProvider::new(&roots.claude_root).resolve(&uri.session_id),
+        ProviderKind::Gemini => GeminiProvider::new(&roots.gemini_root).resolve(&uri.session_id),
         ProviderKind::Opencode => {
             OpencodeProvider::new(&roots.opencode_root).resolve(&uri.session_id)
         }


### PR DESCRIPTION
- add gemini provider resolution for ~/.gemini/tmp/*/chats/session-*.json

- support gemini://<session_id> URI parsing and routing

- extract user/gemini messages from Gemini session JSON

- add CLI/core tests and update README + skill docs

Validation:

- cargo test

- cargo clippy --all-targets --all-features