### PR TITLE
feat(cli): add -o/--output to write rendered output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Unified URI scheme: `agents://<provider>/<thread_path>` is the primary format.
 - Default output is markdown with YAML frontmatter header plus provider-specific body.
 - `-I, --head` outputs frontmatter only.
+- `-o, --output <path>` writes rendered output to a file.
 - For Codex/Claude/Pi main URIs, head output includes discovery fields (`subagents` / `entries`) that replace list-mode aggregation.
 - Subagent markdown views print full parent/subagent URIs in `agents://...` format.
 - Non-fatal diagnostics are kept internal; only fatal errors are printed to `stderr`.
@@ -108,6 +109,7 @@ xurl agents://amp/T-019c0797-c402-7389-bd80-d785c98df295
 ```bash
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 xurl agents://codex/threads/019c871c-b1f9-7f60-9c4f-87ed09f13592
+xurl -o /tmp/codex-thread.md agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 xurl -I agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592/019c87fb-38b9-7843-92b1-832f02598495
 ```

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -97,6 +97,7 @@ Release binaries are published by `release.yml`; `homebrew-publish.yml` updates 
 
 3. Validate mode constraints.
 - `--head` can be used with both main and child URIs.
+- `-o/--output <path>` writes the rendered content to a file instead of stdout.
 - `amp`, `gemini`, and `opencode` do not support child path segments.
 
 4. If child id is unknown, discover first.
@@ -152,6 +153,12 @@ Default output (timeline markdown with frontmatter and timeline entries):
 
 ```bash
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
+```
+
+Write output to a file:
+
+```bash
+xurl -o /tmp/codex-thread.md agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 ```
 
 Frontmatter includes machine-readable source metadata:
@@ -227,6 +234,7 @@ xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592/019c87fb-38b9-7843-92b1
 - Prefer canonical `agents://` URIs when constructing links or commands.
 - Legacy provider schemes are accepted, so keep workflows compatible with existing links.
 - Use default markdown output and read frontmatter (`thread_source`) when raw file access is needed.
+- Use `-o/--output` when the user asks to persist rendered output to a specific file path.
 - If the user asks for subagent aggregation, use `-I/--head` with the parent thread URI and read `subagents`.
 - If the user asks for Pi session navigation targets, use `-I/--head` with `agents://pi/<session_id>` and read `entries`.
 - If the user requests exact records, read the `thread_source` path from frontmatter.

--- a/xurl-cli/tests/cli.rs
+++ b/xurl-cli/tests/cli.rs
@@ -273,6 +273,45 @@ fn default_outputs_markdown() {
 }
 
 #[test]
+fn output_flag_writes_markdown_to_file() {
+    let temp = setup_codex_tree();
+    let output_dir = tempdir().expect("tempdir");
+    let output_path = output_dir.path().join("thread.md");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("CODEX_HOME", temp.path())
+        .env("CLAUDE_CONFIG_DIR", temp.path().join("missing-claude"))
+        .arg(codex_uri())
+        .arg("-o")
+        .arg(&output_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let written = fs::read_to_string(output_path).expect("read output");
+    assert!(written.contains("---\n"));
+    assert!(written.contains("# Thread"));
+    assert!(written.contains("hello"));
+}
+
+#[test]
+fn output_flag_returns_error_when_parent_directory_missing() {
+    let temp = setup_codex_tree();
+    let missing_parent = temp.path().join("missing-parent");
+    let output_path = missing_parent.join("thread.md");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("CODEX_HOME", temp.path())
+        .env("CLAUDE_CONFIG_DIR", temp.path().join("missing-claude"))
+        .arg(codex_uri())
+        .arg("--output")
+        .arg(&output_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error: i/o error on"));
+}
+
+#[test]
 fn agents_uri_outputs_markdown() {
     let temp = setup_codex_tree();
 


### PR DESCRIPTION
## Summary
- add `-o, --output <PATH>` to `xurl-cli` so rendered output can be written to a target file
- keep existing stdout behavior unchanged when `-o` is not provided
- map file write failures to existing `xurl_core::XurlError::Io` for consistent non-zero exit behavior
- add CLI integration tests for successful file output and missing parent directory errors
- sync user-facing docs in `README.md` and `skills/xurl/SKILL.md`

## Testing
- `cargo test -p xurl-cli`
