### PR TITLE
Add provider write mode and refocus docs for end users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,19 @@
   - `skills/xurl/SKILL.md`
 - A change is not complete if runtime behavior and skill/readme docs diverge.
 
+## Documentation Audience & Style
+- Treat documentation as user-facing by default. Focus on capabilities and usage, not implementation details.
+- Do not frame docs as "what xurl is not". State what users can do and how to do it.
+- Keep wording task-oriented and action-first (for example: read, discover, start, continue, save).
+- Prefer conversation-oriented language in user docs. Use `thread/session` only when required by literal CLI syntax, URI forms, or field names.
+- `README.md` is for human users:
+  - prioritize quick onboarding, command examples, option semantics, provider capability boundaries, and troubleshooting.
+  - avoid internal architecture, backend adapter design, and code-structure explanations unless strictly necessary.
+- `skills/xurl/SKILL.md` is for agent users:
+  - prioritize execution workflow (`when to use`, `read/discover/write steps`, command rules, failure handling).
+  - provide concise decision rules that help agents choose the right command without background theory.
+- Keep `README.md` and `skills/xurl/SKILL.md` consistent in terminology, capability matrix, and command behavior.
+
 ## Minimal Change Strategy for Agents
 - Keep patches as small as possible: touch only the crate that owns the behavior, avoid cross-crate refactors unless the fix explicitly requires both `xurl-core` and `xurl-cli`.
 - Unless the user asks for new optional behavior, do not add new dependencies, features, or files; if you see adjacent concerns, surface them as follow-up items instead of folding them into the current change.

--- a/README.md
+++ b/README.md
@@ -4,46 +4,12 @@
 
 > Also known as **Xuanwo's URL**.
 
-## Features
+## What xURL Can Do
 
-- Multi-agent thread resolution:
-  - <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp
-  - <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex
-  - <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude
-  - <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini
-  - <img src=".github/assets/pi-logo-dark.svg" alt="Pi logo" width="16" height="16" /> Pi
-- <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode
-- Unified URI scheme: `agents://<provider>/<thread_path>` is the primary format.
-- Default output is markdown with YAML frontmatter header plus provider-specific body.
-- `-I, --head` outputs frontmatter only.
-- `-o, --output <path>` writes rendered output to a file.
-- For Codex/Claude/Pi main URIs, head output includes discovery fields (`subagents` / `entries`) that replace list-mode aggregation.
-- Subagent markdown views print full parent/subagent URIs in `agents://...` format.
-- Non-fatal diagnostics are kept internal; only fatal errors are printed to `stderr`.
-- Automatically respects official environment variables and default local data roots for each supported agent.
-
-## Install
-
-Homebrew:
-
-```bash
-brew tap xuanwo/tap
-brew install xurl
-```
-
-PyPI via `uv`:
-
-```bash
-uv tool install xuanwo-xurl
-xurl --version
-```
-
-npm:
-
-```bash
-npm install -g @xuanwo/xurl
-xurl --version
-```
+- Read an agent conversation as markdown.
+- Discover subagent/branch navigation targets.
+- Start a new conversation with agents.
+- Continue an existing conversation with follow-up prompts.
 
 ## Quick Start
 
@@ -59,162 +25,80 @@ npx skills add Xuanwo/xurl
 Please summarize this thread: agents://codex/xxx_thread
 ```
 
-## Repository Usage
+## Usage
 
-Run `xurl` directly from source:
-
-```bash
-cargo run -p xurl-cli -- --help
-```
-
-Run the test suite:
-
-```bash
-cargo test --workspace
-```
-
-Run CLI integration tests only:
-
-```bash
-cargo test -p xurl-cli --test cli
-```
-
-Release process summary:
-
-1. Bump crate versions in `xurl-core/Cargo.toml` and `xurl-cli/Cargo.toml`.
-2. Push to `main`.
-3. Create and push a tag like `v0.0.14`.
-4. GitHub Actions will publish release assets, npm, PyPI, and Homebrew updates.
-
-## Projects in This Repository
-
-- [`xurl-core`](./xurl-core): core URI parsing, provider resolution, thread reading, and markdown rendering.
-- [`xurl-cli`](./xurl-cli): CLI entrypoint and argument handling for `xurl`.
-- [`npm`](./npm): Node.js wrapper package source for [`@xuanwo/xurl`](https://www.npmjs.com/package/@xuanwo/xurl).
-- [`pyproject.toml`](./pyproject.toml): Python package metadata for [`xuanwo-xurl`](https://pypi.org/project/xuanwo-xurl/).
-- [`homebrew-tap`](https://github.com/Xuanwo/homebrew-tap): Homebrew formula repository (`xuanwo/tap`).
-- [`skills/xurl`](./skills/xurl/SKILL.md): Codex skill instructions for using `xurl`.
-
-## URL Format
-
-Primary URI format:
-
-```text
-agents://<provider>/<thread_path>
-```
-
-ASCII breakdown:
-
-```text
-agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592/019c87fb-38b9-7843-92b1-832f02598495
-^^^^^^   ^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-scheme   provider thread_path (provider-specific: main thread, optional child thread)
-```
-
-## Agents
-
-### Amp
-
-- Supported URIs:
-  - `agents://amp/<thread_id>`
-- Thread id format:
-  - `T-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
-- Resolution:
-  - `XDG_DATA_HOME/amp/threads/<thread_id>.json`
-  - fallback: `~/.local/share/amp/threads/<thread_id>.json`
-- Example:
-
-```bash
-xurl agents://amp/T-019c0797-c402-7389-bd80-d785c98df295
-```
-
-### Codex
-
-- Supported URIs:
-  - `agents://codex/<session_id>`
-  - `agents://codex/threads/<session_id>`
-  - `agents://codex/<main_session_id>/<agent_id>`
-- Subagent modes:
-  - Aggregate header only: `xurl -I agents://codex/<main_session_id>`
-  - Drill-down: `xurl agents://codex/<main_session_id>/<agent_id>`
-- Resolution order:
-  - SQLite thread index under `CODEX_HOME` (`state_<version>.sqlite` first, then `state.sqlite`) via `threads(id, rollout_path, archived)`.
-  - Filesystem fallback under `sessions/` and `archived_sessions/` for `rollout-*.jsonl`.
-- Examples:
+Read an agent conversation:
 
 ```bash
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
-xurl agents://codex/threads/019c871c-b1f9-7f60-9c4f-87ed09f13592
-xurl -o /tmp/codex-thread.md agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
+```
+
+Discover child targets:
+
+```bash
 xurl -I agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
-xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592/019c87fb-38b9-7843-92b1-832f02598495
-```
-
-### Claude
-
-- Supported URIs:
-  - `agents://claude/<session_id>`
-  - `agents://claude/<main_session_id>/<agent_id>`
-- Subagent modes:
-  - Aggregate header only: `xurl -I agents://claude/<main_session_id>`
-  - Drill-down: `xurl agents://claude/<main_session_id>/<agent_id>`
-- Example:
-
-```bash
-xurl agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f
 xurl -I agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f
-xurl agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f/acompact-69d537
-```
-
-### OpenCode
-
-- Supported URIs:
-  - `agents://opencode/<session_id>`
-- Example:
-
-```bash
-xurl agents://opencode/ses_43a90e3adffejRgrTdlJa48CtE
-```
-
-### Gemini
-
-- Supported URI:
-  - `agents://gemini/<session_id>`
-- Session id format:
-  - `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
-- Resolution:
-  - `GEMINI_CLI_HOME/.gemini/tmp/*/chats/session-*.json`
-  - fallback: `~/.gemini/tmp/*/chats/session-*.json`
-- Example:
-
-```bash
-xurl agents://gemini/29d207db-ca7e-40ba-87f7-e14c9de60613
-```
-
-### Pi
-
-- Supported URIs:
-  - `agents://pi/<session_id>`
-  - `agents://pi/<session_id>/<entry_id>`
-- Session id format:
-  - `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
-- Resolution:
-  - `PI_CODING_AGENT_DIR/sessions/**/*.jsonl`
-  - fallback: `~/.pi/agent/sessions/**/*.jsonl`
-- Rendering:
-  - `agents://pi/<session_id>` renders the latest leaf branch in the session tree.
-  - `agents://pi/<session_id>/<entry_id>` renders the branch ending at the specified entry id.
-  - `xurl -I agents://pi/<session_id>` outputs `entries` in frontmatter for drill-down discovery.
-- Example:
-
-```bash
-xurl agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f
-xurl agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f/d1b2c3d4
 xurl -I agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f
 ```
 
-## Release Automation
+Start a new agent conversation:
 
-- `release.yml` (tag push `v*`) builds native binaries and publishes GitHub release assets (`xurl-<version>-<target>.tar.gz` + checksums + manifest).
-- `homebrew-publish.yml` consumes `release.yml` metadata and updates `xuanwo/tap` formula.
-- `npm-publish.yml` and `pypi-publish.yml` keep their original filenames for trusted publisher compatibility, but now consume artifacts from `release.yml` instead of rebuilding binaries.
+```bash
+xurl agents://codex -d "Draft a migration plan"
+xurl agents://claude -d @prompt.txt
+```
+
+Continue an existing conversation:
+
+```bash
+xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592 -d "Continue"
+cat prompt.md | xurl agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f -d @-
+```
+
+Save output:
+
+```bash
+xurl -o /tmp/conversation.md agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
+```
+
+## Command Reference
+
+```bash
+xurl [OPTIONS] <URI>
+```
+
+Options:
+
+- `-I, --head`: output frontmatter/discovery info only.
+- `-d, --data <DATA>`: write payload (repeatable).
+- `-o, --output <PATH>`: write command output to file.
+
+`--data` supports:
+
+- text: `-d "hello"`
+- file: `-d @prompt.txt`
+- stdin: `-d @-`
+
+## Providers
+
+| Provider | Query | Create |
+| --- | --- | --- |
+| <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp | Yes | No |
+| <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex | Yes | Yes |
+| <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude | Yes | Yes |
+| <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini | Yes | No |
+| <img src=".github/assets/pi-logo-dark.svg" alt="Pi logo" width="16" height="16" /> Pi | Yes | No |
+| <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode | Yes | No |
+
+## URI Formats
+
+```text
+agents://<provider>/<conversation_target>
+```
+
+For examples:
+
+```text
+agents://codex/<conversation_id>
+agents://claude/<conversation_id>
+```

--- a/xurl-cli/src/main.rs
+++ b/xurl-cli/src/main.rs
@@ -1,10 +1,14 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::{fs, io};
+
+use std::io::{Read, Write};
 
 use clap::Parser;
 use xurl_core::{
-    ProviderRoots, ThreadUri, XurlError, render_subagent_view_markdown,
-    render_thread_head_markdown, render_thread_markdown, resolve_subagent_view, resolve_thread,
+    ProviderKind, ProviderRoots, ThreadUri, WriteEventSink, WriteRequest, WriteResult, XurlError,
+    render_subagent_view_markdown, render_thread_head_markdown, render_thread_markdown,
+    resolve_subagent_view, resolve_thread, write_thread,
 };
 
 #[derive(Debug, Parser)]
@@ -17,6 +21,10 @@ struct Cli {
     #[arg(short = 'I', long)]
     head: bool,
 
+    /// Send write-mode payload data; may be repeated. Prefix with @file or @- for stdin.
+    #[arg(short = 'd', long = "data", value_name = "DATA")]
+    data: Vec<String>,
+
     /// Write output to a file instead of stdout
     #[arg(short = 'o', long = "output", value_name = "PATH")]
     output: Option<PathBuf>,
@@ -28,41 +36,67 @@ fn main() -> ExitCode {
     match run(cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("error: {err}");
+            eprintln!("error: {}", user_facing_error(&err));
             ExitCode::from(1)
         }
     }
 }
 
 fn run(cli: Cli) -> xurl_core::Result<()> {
-    let Cli { uri, head, output } = cli;
+    let Cli {
+        uri,
+        head,
+        data,
+        output,
+    } = cli;
     let roots = ProviderRoots::from_env_or_home()?;
-    let uri = ThreadUri::parse(&uri)?;
-
     let output = output.as_deref();
+    if data.is_empty() {
+        let uri = ThreadUri::parse(&uri)?;
+        if head {
+            let head = render_thread_head_markdown(&uri, &roots)?;
+            return write_output(output, &head);
+        }
 
-    if head {
-        let head = render_thread_head_markdown(&uri, &roots)?;
-        return write_output(output, &head);
+        let markdown = if matches!(
+            uri.provider,
+            xurl_core::ProviderKind::Codex | xurl_core::ProviderKind::Claude
+        ) && uri.agent_id.is_some()
+        {
+            let head = render_thread_head_markdown(&uri, &roots)?;
+            let view = resolve_subagent_view(&uri, &roots, false)?;
+            let body = render_subagent_view_markdown(&view);
+            format!("{head}\n{body}")
+        } else {
+            let head = render_thread_head_markdown(&uri, &roots)?;
+            let resolved = resolve_thread(&uri, &roots)?;
+            let body = render_thread_markdown(&uri, &resolved)?;
+            format!("{head}\n{body}")
+        };
+
+        return write_output(output, &markdown);
     }
 
-    let markdown = if matches!(
-        uri.provider,
-        xurl_core::ProviderKind::Codex | xurl_core::ProviderKind::Claude
-    ) && uri.agent_id.is_some()
-    {
-        let head = render_thread_head_markdown(&uri, &roots)?;
-        let view = resolve_subagent_view(&uri, &roots, false)?;
-        let body = render_subagent_view_markdown(&view);
-        format!("{head}\n{body}")
-    } else {
-        let head = render_thread_head_markdown(&uri, &roots)?;
-        let resolved = resolve_thread(&uri, &roots)?;
-        let body = render_thread_markdown(&uri, &resolved)?;
-        format!("{head}\n{body}")
-    };
+    if head {
+        return Err(XurlError::InvalidMode(
+            "head mode (-I/--head) cannot be combined with write mode (-d/--data)".to_string(),
+        ));
+    }
 
-    write_output(output, &markdown)
+    let prompt = build_prompt(&data)?;
+    let target = parse_write_target(&uri)?;
+    let mut sink = CliWriteSink::new(output, target.action)?;
+    let result = write_thread(
+        target.provider,
+        &roots,
+        &WriteRequest {
+            prompt,
+            session_id: target.session_id,
+        },
+        &mut sink,
+    )?;
+    sink.finish(&result)?;
+    Ok(())
 }
 
 fn write_output(path: Option<&Path>, content: &str) -> xurl_core::Result<()> {
@@ -76,4 +110,212 @@ fn write_output(path: Option<&Path>, content: &str) -> xurl_core::Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum WriteAction {
+    Create,
+    Append,
+}
+
+#[derive(Debug, Clone)]
+struct WriteTarget {
+    provider: ProviderKind,
+    session_id: Option<String>,
+    action: WriteAction,
+}
+
+fn parse_write_target(input: &str) -> xurl_core::Result<WriteTarget> {
+    if let Some(provider) = parse_collection_provider(input) {
+        return Ok(WriteTarget {
+            provider,
+            session_id: None,
+            action: WriteAction::Create,
+        });
+    }
+
+    let uri = ThreadUri::parse(input)?;
+    if uri.agent_id.is_some() {
+        return Err(XurlError::InvalidMode(
+            "write mode only supports main thread URIs: agents://<provider>/<session_id>"
+                .to_string(),
+        ));
+    }
+
+    Ok(WriteTarget {
+        provider: uri.provider,
+        session_id: Some(uri.session_id),
+        action: WriteAction::Append,
+    })
+}
+
+fn parse_collection_provider(input: &str) -> Option<ProviderKind> {
+    let target = input.strip_prefix("agents://")?;
+    if target.is_empty() || target.contains('/') {
+        return None;
+    }
+
+    match target {
+        "amp" => Some(ProviderKind::Amp),
+        "codex" => Some(ProviderKind::Codex),
+        "claude" => Some(ProviderKind::Claude),
+        "gemini" => Some(ProviderKind::Gemini),
+        "pi" => Some(ProviderKind::Pi),
+        "opencode" => Some(ProviderKind::Opencode),
+        _ => None,
+    }
+}
+
+fn build_prompt(data: &[String]) -> xurl_core::Result<String> {
+    let mut chunks = Vec::with_capacity(data.len());
+    for raw in data {
+        chunks.push(load_data(raw)?);
+    }
+    Ok(chunks.join("\n"))
+}
+
+fn load_data(raw: &str) -> xurl_core::Result<String> {
+    if raw == "@-" {
+        let mut input = String::new();
+        io::stdin()
+            .read_to_string(&mut input)
+            .map_err(|source| XurlError::Io {
+                path: PathBuf::from("<stdin>"),
+                source,
+            })?;
+        return Ok(input);
+    }
+
+    if let Some(path) = raw.strip_prefix('@') {
+        let path = PathBuf::from(path);
+        return fs::read_to_string(&path).map_err(|source| XurlError::Io { path, source });
+    }
+
+    Ok(raw.to_string())
+}
+
+enum WriteDestination {
+    Stdout,
+    File { path: PathBuf, file: fs::File },
+}
+
+struct CliWriteSink {
+    destination: WriteDestination,
+    action: WriteAction,
+    uri_emitted: bool,
+    text_emitted: bool,
+}
+
+impl CliWriteSink {
+    fn new(output: Option<&Path>, action: WriteAction) -> xurl_core::Result<Self> {
+        let destination = if let Some(path) = output {
+            let file = fs::File::create(path).map_err(|source| XurlError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            WriteDestination::File {
+                path: path.to_path_buf(),
+                file,
+            }
+        } else {
+            WriteDestination::Stdout
+        };
+
+        Ok(Self {
+            destination,
+            action,
+            uri_emitted: false,
+            text_emitted: false,
+        })
+    }
+
+    fn emit_uri_once(&mut self, provider: ProviderKind, session_id: &str) {
+        if self.uri_emitted {
+            return;
+        }
+        let verb = match self.action {
+            WriteAction::Create => "created",
+            WriteAction::Append => "updated",
+        };
+        eprintln!("{verb}: agents://{provider}/{session_id}");
+        self.uri_emitted = true;
+    }
+
+    fn write_delta(&mut self, text: &str) -> xurl_core::Result<()> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        match &mut self.destination {
+            WriteDestination::Stdout => {
+                let mut stdout = io::stdout();
+                stdout
+                    .write_all(text.as_bytes())
+                    .map_err(|source| XurlError::Io {
+                        path: PathBuf::from("<stdout>"),
+                        source,
+                    })?;
+                stdout.flush().map_err(|source| XurlError::Io {
+                    path: PathBuf::from("<stdout>"),
+                    source,
+                })?;
+            }
+            WriteDestination::File { path, file } => {
+                file.write_all(text.as_bytes())
+                    .map_err(|source| XurlError::Io {
+                        path: path.clone(),
+                        source,
+                    })?;
+                file.flush().map_err(|source| XurlError::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+            }
+        }
+        self.text_emitted = true;
+        Ok(())
+    }
+
+    fn finish(&mut self, result: &WriteResult) -> xurl_core::Result<()> {
+        self.emit_uri_once(result.provider, &result.session_id);
+        if !self.text_emitted
+            && let Some(text) = result.final_text.as_deref()
+        {
+            self.write_delta(text)?;
+        }
+        Ok(())
+    }
+}
+
+impl WriteEventSink for CliWriteSink {
+    fn on_session_ready(
+        &mut self,
+        provider: ProviderKind,
+        session_id: &str,
+    ) -> xurl_core::Result<()> {
+        self.emit_uri_once(provider, session_id);
+        Ok(())
+    }
+
+    fn on_text_delta(&mut self, text: &str) -> xurl_core::Result<()> {
+        self.write_delta(text)
+    }
+}
+
+fn user_facing_error(err: &XurlError) -> String {
+    match err {
+        XurlError::CommandNotFound { command } if command.contains("codex") => format!(
+            "{err}\nhint: write mode needs Codex CLI; run `codex --version`, install Codex CLI if missing, then run `codex login`."
+        ),
+        XurlError::CommandNotFound { command } if command.contains("claude") => format!(
+            "{err}\nhint: write mode needs Claude CLI; run `claude --version`, install Claude Code if missing, then authenticate."
+        ),
+        XurlError::CommandFailed { command, .. } if command.contains("codex") => {
+            format!("{err}\nhint: verify authentication with `codex login` and retry.")
+        }
+        XurlError::CommandFailed { command, .. } if command.contains("claude") => format!(
+            "{err}\nhint: verify authentication with `claude auth` (or your configured login flow) and retry."
+        ),
+        _ => err.to_string(),
+    }
 }

--- a/xurl-core/src/error.rs
+++ b/xurl-core/src/error.rs
@@ -19,6 +19,22 @@ pub enum XurlError {
     #[error("provider does not support subagent queries: {0}")]
     UnsupportedSubagentProvider(String),
 
+    #[error("provider does not support write mode: {0}")]
+    UnsupportedProviderWrite(String),
+
+    #[error("command not found: {command}")]
+    CommandNotFound { command: String },
+
+    #[error("command failed: {command} (exit code: {code:?}): {stderr}")]
+    CommandFailed {
+        command: String,
+        code: Option<i32>,
+        stderr: String,
+    },
+
+    #[error("write protocol error: {0}")]
+    WriteProtocol(String),
+
     #[error("serialization error: {0}")]
     Serialization(String),
 

--- a/xurl-core/src/jsonl.rs
+++ b/xurl-core/src/jsonl.rs
@@ -1,0 +1,50 @@
+use std::io::BufRead;
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::error::{Result, XurlError};
+
+pub fn parse_json_line(path: &Path, line_no: usize, line: &str) -> Result<Option<Value>> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let value =
+        serde_json::from_str::<Value>(trimmed).map_err(|source| XurlError::InvalidJsonLine {
+            path: path.to_path_buf(),
+            line: line_no,
+            source,
+        })?;
+    Ok(Some(value))
+}
+
+pub fn parse_jsonl_reader<R, F>(path: &Path, mut reader: R, mut on_value: F) -> Result<()>
+where
+    R: BufRead,
+    F: FnMut(usize, Value) -> Result<()>,
+{
+    let mut line_no = 0usize;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .map_err(|source| XurlError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if bytes == 0 {
+            break;
+        }
+
+        line_no += 1;
+        if let Some(value) = parse_json_line(path, line_no, &line)? {
+            on_value(line_no, value)?;
+        }
+    }
+
+    Ok(())
+}

--- a/xurl-core/src/lib.rs
+++ b/xurl-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod jsonl;
 pub mod model;
 pub mod provider;
 pub mod render;
@@ -8,11 +9,11 @@ pub mod uri;
 pub use error::{Result, XurlError};
 pub use model::{
     MessageRole, PiEntryListView, ProviderKind, ResolutionMeta, ResolvedThread, SubagentDetailView,
-    SubagentListView, SubagentView, ThreadMessage,
+    SubagentListView, SubagentView, ThreadMessage, WriteRequest, WriteResult,
 };
-pub use provider::ProviderRoots;
+pub use provider::{ProviderRoots, WriteEventSink};
 pub use service::{
     render_subagent_view_markdown, render_thread_head_markdown, render_thread_markdown,
-    resolve_subagent_view, resolve_thread,
+    resolve_subagent_view, resolve_thread, write_thread,
 };
 pub use uri::ThreadUri;

--- a/xurl-core/src/model.rs
+++ b/xurl-core/src/model.rs
@@ -41,6 +41,19 @@ pub struct ResolvedThread {
     pub metadata: ResolutionMeta,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteRequest {
+    pub prompt: String,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteResult {
+    pub provider: ProviderKind,
+    pub session_id: String,
+    pub final_text: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum MessageRole {
     User,

--- a/xurl-core/src/provider/amp.rs
+++ b/xurl-core/src/provider/amp.rs
@@ -20,6 +20,10 @@ impl AmpProvider {
 }
 
 impl Provider for AmpProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Amp
+    }
+
     fn resolve(&self, session_id: &str) -> Result<ResolvedThread> {
         let threads_root = self.threads_root();
         let path = threads_root.join(format!("{session_id}.json"));

--- a/xurl-core/src/provider/gemini.rs
+++ b/xurl-core/src/provider/gemini.rs
@@ -91,6 +91,10 @@ impl GeminiProvider {
 }
 
 impl Provider for GeminiProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Gemini
+    }
+
     fn resolve(&self, session_id: &str) -> Result<ResolvedThread> {
         let tmp_root = self.tmp_root();
         let candidates = Self::find_candidates(&tmp_root, session_id);

--- a/xurl-core/src/provider/mod.rs
+++ b/xurl-core/src/provider/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use dirs::home_dir;
 
 use crate::error::{Result, XurlError};
-use crate::model::ResolvedThread;
+use crate::model::{ProviderKind, ResolvedThread, WriteRequest, WriteResult};
 
 pub mod amp;
 pub mod claude;
@@ -13,8 +13,18 @@ pub mod gemini;
 pub mod opencode;
 pub mod pi;
 
+pub trait WriteEventSink {
+    fn on_session_ready(&mut self, provider: ProviderKind, session_id: &str) -> Result<()>;
+    fn on_text_delta(&mut self, text: &str) -> Result<()>;
+}
+
 pub trait Provider {
+    fn kind(&self) -> ProviderKind;
     fn resolve(&self, session_id: &str) -> Result<ResolvedThread>;
+    fn write(&self, req: &WriteRequest, sink: &mut dyn WriteEventSink) -> Result<WriteResult> {
+        let _ = (req, sink);
+        Err(XurlError::UnsupportedProviderWrite(self.kind().to_string()))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/xurl-core/src/provider/opencode.rs
+++ b/xurl-core/src/provider/opencode.rs
@@ -139,6 +139,10 @@ impl OpencodeProvider {
 }
 
 impl Provider for OpencodeProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Opencode
+    }
+
     fn resolve(&self, session_id: &str) -> Result<ResolvedThread> {
         let db_path = self.db_path();
         if !db_path.exists() {

--- a/xurl-core/src/provider/pi.rs
+++ b/xurl-core/src/provider/pi.rs
@@ -92,6 +92,10 @@ impl PiProvider {
 }
 
 impl Provider for PiProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Pi
+    }
+
     fn resolve(&self, session_id: &str) -> Result<ResolvedThread> {
         let sessions_root = self.sessions_root();
         let candidates = Self::find_candidates(&sessions_root, session_id);

--- a/xurl-core/src/render.rs
+++ b/xurl-core/src/render.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use serde_json::Value;
 
 use crate::error::{Result, XurlError};
+use crate::jsonl;
 use crate::model::{MessageRole, ProviderKind, ThreadMessage};
 use crate::uri::ThreadUri;
 
@@ -120,13 +121,9 @@ fn extract_timeline_entries(
             continue;
         }
 
-        let value = serde_json::from_str::<Value>(trimmed).map_err(|source| {
-            XurlError::InvalidJsonLine {
-                path: path.to_path_buf(),
-                line: line_no,
-                source,
-            }
-        })?;
+        let Some(value) = jsonl::parse_json_line(path, line_no, trimmed)? else {
+            continue;
+        };
 
         let extracted = match provider {
             ProviderKind::Amp => None,
@@ -165,13 +162,9 @@ fn extract_pi_entries(
             continue;
         }
 
-        let value = serde_json::from_str::<Value>(trimmed).map_err(|source| {
-            XurlError::InvalidJsonLine {
-                path: path.to_path_buf(),
-                line: line_no,
-                source,
-            }
-        })?;
+        let Some(value) = jsonl::parse_json_line(path, line_no, trimmed)? else {
+            continue;
+        };
 
         if value.get("type").and_then(Value::as_str) == Some("session") {
             continue;


### PR DESCRIPTION
## Summary

This PR turns `xurl` into a full client workflow for agents URIs by adding provider write support while preserving existing query/read behavior.

## What Changed

- Added provider write capability in `xurl-core` via unified provider abstraction.
- Implemented write execution for:
  - Codex (`codex exec --json`, `codex exec resume --json`)
  - Claude (`claude -p --verbose --output-format stream-json`, `--resume`)
- Added `WriteRequest` / `WriteResult` models and write-oriented errors.
- Added `write_thread(...)` service entrypoint.
- Added shared `jsonl` helper and reused it in write flow and selected read parsing paths.
- Extended CLI with write mode:
  - `-d/--data` (repeatable)
  - `@file` and `@-` payload support
  - create vs append routing by URI form
  - streamed assistant output and canonical URI status lines
  - user-facing hints for missing provider CLIs/auth issues
- Added integration tests for write mode success/failure matrix.
- Updated docs and style guidance:
  - `README.md` and `skills/xurl/SKILL.md` rewritten in user-task style
  - provider capability table simplified to `Query` / `Create`
  - added doc audience/style constraints to `AGENTS.md`

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`

All passed.
