### PR TITLE
feat: support agents:// write mode for amp, gemini, pi, and opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,28 +36,13 @@ xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 Discover child targets:
 
 ```bash
-xurl -I agents://amp/T-019c0797-c402-7389-bd80-d785c98df295
 xurl -I agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
-xurl -I agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f
-xurl agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f/acompact-69d537
-xurl agents://gemini/29d207db-ca7e-40ba-87f7-e14c9de60613
-xurl -I agents://gemini/29d207db-ca7e-40ba-87f7-e14c9de60613
-xurl agents://gemini/29d207db-ca7e-40ba-87f7-e14c9de60613/2b112c8a-d80a-4cff-9c8a-6f3e6fbaf7fb
-xurl -I agents://opencode/ses_43a90e3adffejRgrTdlJa48CtE
-xurl agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f
-xurl agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f/d1b2c3d4
-xurl -I agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f
 ```
 
 Drill down into a discovered child target:
 
 ```bash
-xurl agents://amp/T-019c0797-c402-7389-bd80-d785c98df295/T-1abc0797-c402-7389-bd80-d785c98df295
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592/019c87fb-38b9-7843-92b1-832f02598495
-xurl agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f/acompact-69d537
-xurl agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f/72b3a4a8-4f08-40af-8d7f-8b2c77584e89
-xurl agents://pi/12cb4c19-2774-4de4-a0d0-9fa32fbae29f/d1b2c3d4
-xurl agents://opencode/ses_43a90e3adffejRgrTdlJa48CtE/ses_3k2j1h9g8f7d
 ```
 
 OpenCode child linkage is validated via sqlite `session.parent_id`.
@@ -65,14 +50,12 @@ Start a new agent conversation:
 
 ```bash
 xurl agents://codex -d "Draft a migration plan"
-xurl agents://claude -d @prompt.txt
 ```
 
 Continue an existing conversation:
 
 ```bash
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592 -d "Continue"
-cat prompt.md | xurl agents://claude/2823d1df-720a-4c31-ac55-ae8ba726721f -d @-
 ```
 
 Save output:
@@ -103,12 +86,12 @@ Options:
 
 | Provider | Query | Create |
 | --- | --- | --- |
-| <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp | Yes | No |
+| <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp | Yes | Yes |
 | <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex | Yes | Yes |
 | <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude | Yes | Yes |
-| <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini | Yes | No |
-| <img src=".github/assets/pi-logo-dark.svg" alt="Pi logo" width="16" height="16" /> Pi | Yes | No |
-| <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode | Yes | No |
+| <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini | Yes | Yes |
+| <img src=".github/assets/pi-logo-dark.svg" alt="Pi logo" width="16" height="16" /> Pi | Yes | Yes |
+| <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode | Yes | Yes |
 
 ## URI Formats
 
@@ -119,12 +102,5 @@ agents://<provider>/<conversation_target>
 For examples:
 
 ```text
-agents://amp/<thread_id>
-agents://amp/<main_thread_id>/<child_thread_id>
-agents://codex/<conversation_id>
-agents://codex/<main_conversation_id>/<agent_id>
-agents://claude/<conversation_id>
-agents://claude/<main_conversation_id>/<agent_id>
-agents://pi/<conversation_id>/<child_session_id>
-agents://pi/<conversation_id>/<entry_id>
+agents://codex/threads/<conversation_id>
 ```

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -3,6 +3,13 @@ name: xurl
 description: Use xurl to read, discover, and write AI agent conversations through agents:// URIs.
 ---
 
+## When to Use
+
+- User gives `agents://...` URI.
+- User asks to read or summarize a conversation.
+- User asks to discover child targets before drill-down.
+- User asks to start or continue conversations for providers.
+
 ## Installation
 
 Pick up the preferred ways based on current context:
@@ -62,32 +69,18 @@ npm update -g @xuanwo/xurl
 xurl --version
 ```
 
-## When to Use
-
-- User gives `agents://...` URI.
-- User asks to read or summarize a conversation.
-- User asks to discover child targets before drill-down.
-- User asks to start or continue conversations for providers.
-
 ## Core Workflows
 
 ### 1) Read
 
 ```bash
 xurl agents://codex/<conversation_id>
-xurl agents://claude/<conversation_id>
-xurl agents://gemini/<conversation_id>
 ```
 
 ### 2) Discover
 
 ```bash
-xurl -I agents://amp/T-019c0797-c402-7389-bd80-d785c98df295
 xurl -I agents://codex/<conversation_id>
-xurl -I agents://claude/<conversation_id>
-xurl -I agents://gemini/<conversation_id>
-xurl -I agents://opencode/<conversation_id>
-xurl -I agents://pi/<session_id>
 ```
 
 Use returned `subagents` or `entries` URI for next step.
@@ -96,11 +89,7 @@ OpenCode child linkage is validated by sqlite `session.parent_id`.
 ### 2.1) Drill Down Child Thread
 
 ```bash
-xurl agents://amp/T-019c0797-c402-7389-bd80-d785c98df295/T-1abc0797-c402-7389-bd80-d785c98df295
 xurl agents://codex/<main_conversation_id>/<agent_id>
-xurl agents://claude/<main_conversation_id>/<agent_id>
-xurl agents://pi/<conversation_id>/<child_session_id>
-xurl agents://pi/<conversation_id>/<entry_id>
 ```
 
 ### 3) Write
@@ -148,61 +137,24 @@ Write output:
 
 Canonical:
 
-- `agents://codex/<session_id>`
-- `agents://codex/threads/<session_id>`
-- `agents://codex/<main_session_id>/<agent_id>`
-- `agents://amp/<thread_id>`
-- `agents://claude/<session_id>`
-- `agents://claude/<main_session_id>/<agent_id>`
-- `agents://gemini/<session_id>`
-- `agents://gemini/<main_session_id>/<child_session_id>`
-- `agents://pi/<session_id>`
-- `agents://pi/<session_id>/<entry_id>`
-- `agents://opencode/<session_id>`
+- `agents://<provider>/<conversation_id>`
+- `agents://<provider>/<conversation_id>/<child_id>`
 
 Child drill-down URI forms:
 
-- `agents://amp/<main_thread_id>/<child_thread_id>`
-- `agents://codex/<main_conversation_id>/<agent_id>`
-- `agents://claude/<main_conversation_id>/<agent_id>`
-- `agents://pi/<conversation_id>/<entry_id>`
+- `agents://<provider>/<main_conversation_id>/<child_id>`
 
 Legacy compatibility:
 
-- `codex://<session_id>`
-- `codex://threads/<session_id>`
-- `codex://<main_session_id>/<agent_id>`
-- `amp://<thread_id>`
-- `claude://<session_id>`
-- `claude://<main_session_id>/<agent_id>`
-- `gemini://<session_id>`
-- `gemini://<main_session_id>/<child_session_id>`
-- `pi://<session_id>`
-- `pi://<session_id>/<entry_id>`
-- `opencode://<session_id>`
+- `<provider>://<conversation_id>`
+- `<provider>://<conversation_id>/<child_id>`
 
 Pi child forms:
 
-- `agents://pi/<main_session_id>/<child_session_id>`: UUID child session drill-down
-- `agents://pi/<session_id>/<entry_id>`: entry-based branch drill-down
+- `agents://pi/<session_id>/<child_id>`: `<child_id>` can be a UUID child session id or an entry id
 
 ## Failure Handling
 
-Common failures:
+### `command not found: <agent>`
 
-- invalid URI
-- invalid mode combination
-- conversation not found
-- unsupported write provider
-
-Write dependency errors:
-
-- `command not found: codex`
-  - run `codex --version`
-  - install Codex CLI
-  - run `codex login`
-
-- `command not found: claude`
-  - run `claude --version`
-  - install Claude Code CLI
-  - authenticate and retry
+search web to install the `<agent>` `CLI, ask users to authenticate the agent

--- a/xurl-cli/src/main.rs
+++ b/xurl-cli/src/main.rs
@@ -309,17 +309,41 @@ impl WriteEventSink for CliWriteSink {
 
 fn user_facing_error(err: &XurlError) -> String {
     match err {
+        XurlError::CommandNotFound { command } if command.contains("amp") => format!(
+            "{err}\nhint: write mode needs Amp CLI; run `amp --version`, install Amp CLI if missing, then run `amp login`."
+        ),
         XurlError::CommandNotFound { command } if command.contains("codex") => format!(
             "{err}\nhint: write mode needs Codex CLI; run `codex --version`, install Codex CLI if missing, then run `codex login`."
         ),
         XurlError::CommandNotFound { command } if command.contains("claude") => format!(
             "{err}\nhint: write mode needs Claude CLI; run `claude --version`, install Claude Code if missing, then authenticate."
         ),
+        XurlError::CommandNotFound { command } if command.contains("gemini") => format!(
+            "{err}\nhint: write mode needs Gemini CLI; run `gemini --version`, install Gemini CLI if missing, then authenticate."
+        ),
+        XurlError::CommandNotFound { command } if command.contains("pi") => format!(
+            "{err}\nhint: write mode needs pi CLI; run `pi --version`, install pi if missing, then configure provider credentials."
+        ),
+        XurlError::CommandNotFound { command } if command.contains("opencode") => format!(
+            "{err}\nhint: write mode needs OpenCode CLI; run `opencode --version`, install OpenCode if missing, then configure providers/models."
+        ),
+        XurlError::CommandFailed { command, .. } if command.contains("amp") => {
+            format!("{err}\nhint: verify authentication with `amp login` and retry.")
+        }
         XurlError::CommandFailed { command, .. } if command.contains("codex") => {
             format!("{err}\nhint: verify authentication with `codex login` and retry.")
         }
         XurlError::CommandFailed { command, .. } if command.contains("claude") => format!(
             "{err}\nhint: verify authentication with `claude auth` (or your configured login flow) and retry."
+        ),
+        XurlError::CommandFailed { command, .. } if command.contains("gemini") => format!(
+            "{err}\nhint: verify Gemini authentication/configuration and retry the command directly once."
+        ),
+        XurlError::CommandFailed { command, .. } if command.contains("pi") => format!(
+            "{err}\nhint: verify pi provider/model credentials and retry with `pi -p \"hello\" --mode json`."
+        ),
+        XurlError::CommandFailed { command, .. } if command.contains("opencode") => format!(
+            "{err}\nhint: verify OpenCode provider/model configuration and retry with `opencode run \"hello\" --format json`."
         ),
         _ => err.to_string(),
     }


### PR DESCRIPTION
## Summary
- add write-mode provider implementations for Amp, Gemini, Pi, and OpenCode
- support both create (`agents://<provider> -d ...`) and append (`agents://<provider>/<session_id> -d ...`) paths
- add provider-specific write error hints in CLI and expand write-mode integration tests
- update docs to reflect create support and reduce duplicated examples

## Testing
- cargo test --workspace
