### PR TITLE
chore: decouple release tag from crate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,23 +35,6 @@ jobs:
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "is_prerelease=${is_prerelease}" >> "${GITHUB_OUTPUT}"
 
-      - name: Ensure tag version matches Cargo version
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ steps.resolve-version.outputs.version }}"
-          cargo_version="$(awk -F '\"' '$1 ~ /^version = / { print $2; exit }' xurl-cli/Cargo.toml)"
-
-          if [[ -z "${cargo_version}" ]]; then
-            echo "Failed to read version from xurl-cli/Cargo.toml"
-            exit 1
-          fi
-
-          if [[ "${tag}" != "${cargo_version}" ]]; then
-            echo "Tag version (${tag}) does not match Cargo version (${cargo_version})."
-            exit 1
-          fi
-
   build-native:
     name: Build native binary for ${{ matrix.platform.target }}
     needs: validate-tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "xurl-cli"
-version = "0.0.16"
+version = "0.0.0-dev"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "xurl-core"
-version = "0.0.16"
+version = "0.0.0-dev"
 dependencies = [
  "dirs",
  "grep",

--- a/xurl-cli/Cargo.toml
+++ b/xurl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xurl-cli"
-version = "0.0.16"
+version = "0.0.0-dev"
 edition = "2024"
 
 [[bin]]

--- a/xurl-core/Cargo.toml
+++ b/xurl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xurl-core"
-version = "0.0.16"
+version = "0.0.0-dev"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- set `xurl-core` and `xurl-cli` crate versions to `0.0.0-dev`
- sync `Cargo.lock` package versions to `0.0.0-dev`
- remove release workflow guard that required tag version to match crate version

## Verification
- cargo test
