### PR TITLE
feat: allow omitting agents:// prefix in URI input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Read an agent conversation:
 
 ```bash
 xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
+# equivalent shorthand:
+xurl codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 ```
 
 Query provider threads:
@@ -52,6 +54,9 @@ Query provider threads:
 xurl agents://codex
 xurl 'agents://codex?q=spawn_agent'
 xurl 'agents://claude?q=agent&limit=5'
+# equivalent shorthand:
+xurl codex
+xurl 'codex?q=spawn_agent'
 ```
 
 Discover child targets:
@@ -70,6 +75,8 @@ Start a new agent conversation:
 
 ```bash
 xurl agents://codex -d "Draft a migration plan"
+# equivalent shorthand:
+xurl codex -d "Draft a migration plan"
 ```
 
 Continue an existing conversation:
@@ -106,12 +113,13 @@ xurl [OPTIONS] <URI>
 ## URI Reference
 
 ```text
-agents://<provider>[/<conversation_id>[/<child_id>]][?<query>]
+[agents://]<provider>[/<conversation_id>[/<child_id>]][?<query>]
 |------|  |--------|  |---------------------------|  |------|
- scheme    provider         optional path parts        query
+ optional   provider         optional path parts        query
+ scheme
 ```
 
-- `scheme`: fixed as `agents`.
+- `scheme`: optional `agents://` prefix. If omitted, `xurl` treats input as an `agents` URI shorthand.
 - `provider`: target provider name, such as `codex`, `claude`, `gemini`, `amp`, `pi`, `opencode`.
 - `conversation_id`: main conversation identifier.
 - `child_id`: child/subagent identifier under a main conversation.

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: xurl
-description: Use xurl to read, discover, and write AI agent conversations through agents:// URIs.
+description: Use xurl to read, discover, and write AI agent conversations through agents:// URIs or shorthand provider paths.
 ---
 
 ## When to Use
 
 - User gives `agents://...` URI.
+- User gives shorthand URI like `codex/...` or `codex?...`.
 - User asks to list/search provider threads.
 - User asks to read or summarize a conversation.
 - User asks to discover child targets before drill-down.
@@ -78,6 +79,8 @@ List latest provider threads:
 
 ```bash
 xurl agents://codex
+# equivalent shorthand:
+xurl codex
 ```
 
 Keyword query with optional limit (default `10`):
@@ -91,6 +94,8 @@ xurl 'agents://claude?q=agent&limit=5'
 
 ```bash
 xurl agents://codex/<conversation_id>
+# equivalent shorthand:
+xurl codex/<conversation_id>
 ```
 
 ### 3) Discover
@@ -114,6 +119,8 @@ Create:
 
 ```bash
 xurl agents://codex -d "Start a new conversation"
+# equivalent shorthand:
+xurl codex -d "Start a new conversation"
 ```
 
 Append:
@@ -152,14 +159,15 @@ cat prompt.md | xurl agents://claude -d @-
 URI Anatomy (ASCII):
 
 ```text
-agents://<provider>[/<conversation_id>[/<child_id>]][?<query>]
+[agents://]<provider>[/<conversation_id>[/<child_id>]][?<query>]
 |------|  |--------|  |---------------------------|  |------|
- scheme    provider         optional path parts        query
+ optional   provider         optional path parts        query
+ scheme
 ```
 
 Component meanings:
 
-- `scheme`: fixed as `agents`
+- `scheme`: optional `agents://` prefix; omitted form is treated as shorthand
 - `provider`: provider name
 - `conversation_id`: main conversation id
 - `child_id`: child/subagent id

--- a/xurl-cli/src/main.rs
+++ b/xurl-cli/src/main.rs
@@ -17,7 +17,7 @@ use xurl_core::{
 #[derive(Debug, Parser)]
 #[command(name = "xurl", version, about = "Resolve and read code-agent threads")]
 struct Cli {
-    /// Thread URI like agents://codex/<session_id>, agents://claude/<session_id>, agents://pi/<session_id>/<child_or_entry_id>, or legacy forms like codex://<session_id>
+    /// Thread URI like agents://codex/<session_id>, codex/<session_id>, agents://claude/<session_id>, agents://pi/<session_id>/<child_or_entry_id>, or legacy forms like codex://<session_id>
     uri: String,
 
     /// Output frontmatter only (header mode)


### PR DESCRIPTION
## Summary
- accept shorthand URI input without `agents://` prefix (for example `codex`, `codex/<conversation_id>`, `codex?q=...`)
- keep existing legacy provider schemes (like `codex://...`) unchanged
- update CLI/docs/skill examples to document shorthand usage

## Changes
- refactor `AgentsUri` parsing to handle three modes:
  - explicit `agents://...`
  - legacy provider scheme (`codex://...`, etc.)
  - shorthand agents form without scheme (`codex/...`)
- extend collection query parser to accept shorthand provider query URIs
- add unit tests for shorthand collection/main/subagent/query parsing paths
- add CLI integration tests for shorthand read/query/create flows
- update `README.md`, `skills/xurl/SKILL.md`, and CLI help text

## Verification
- `cargo fmt`
- `cargo test -p xurl-core`
- `cargo test -p xurl-cli`
