### PR TITLE
write: passthrough URI query params without normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ xurl agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592 -d "Continue"
 Create with query parameters:
 
 ```bash
-xurl "agents://codex?workdir=%2FUsers%2Falice%2Frepo&add_dir=%2FUsers%2Falice%2Fshared&model=gpt-5" -d "Review this patch"
+xurl "agents://codex?cd=%2FUsers%2Falice%2Frepo&add-dir=%2FUsers%2Falice%2Fshared&model=gpt-5" -d "Review this patch"
 ```
 
 Save output:
@@ -130,14 +130,13 @@ xurl [OPTIONS] <URI>
 
 - `q=<keyword>`: filters discovery results by keyword. Use when you want to find conversations by topic.
 - `limit=<n>`: limits discovery result count (default `10`). Use when you need a shorter or longer result list.
-- `workdir=<dir>`: sets the initial working directory for create mode. Use when a new conversation should run in a specific project root.
-- `add_dir=<dir>`: adds additional directories for create mode (repeatable). Use when a new conversation needs access to multiple directories.
-- `<key>=<value>`: passes a custom provider option in create mode. Use when you need provider-specific behavior not covered by standard keys.
+- `<key>=<value>`: in write mode (`-d`), `xurl` forwards as `--<key> <value>` to the provider CLI.
+- `<flag>`: in write mode (`-d`), `xurl` forwards as `--<flag>` to the provider CLI.
 
 Examples:
 
 ```text
 agents://codex?q=spawn_agent&limit=10
 agents://codex/threads/<conversation_id>
-agents://codex?workdir=%2FUsers%2Falice%2Frepo
+agents://codex?cd=%2FUsers%2Falice%2Frepo&add-dir=%2FUsers%2Falice%2Fshared
 ```

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -132,7 +132,7 @@ xurl agents://codex/<conversation_id> -d "Continue"
 Create with query parameters:
 
 ```bash
-xurl "agents://codex?workdir=%2FUsers%2Falice%2Frepo&add_dir=%2FUsers%2Falice%2Fshared&model=gpt-5" -d "Review this patch"
+xurl "agents://codex?cd=%2FUsers%2Falice%2Frepo&add-dir=%2FUsers%2Falice%2Fshared&model=gpt-5" -d "Review this patch"
 ```
 
 Payload from file/stdin:
@@ -185,9 +185,8 @@ Query parameters:
 
 - `q=<keyword>`: filter discovery results by keyword. Use when searching conversations by topic.
 - `limit=<n>`: cap discovery results (default `10`). Use when you want fewer or more results.
-- `workdir=<dir>`: set initial working directory for create mode. Use when new work must start in a specific repo.
-- `add_dir=<dir>`: add extra directories for create mode (repeatable). Use when new work needs multiple directories.
-- `<key>=<value>`: pass custom provider option in create mode. Use when standard keys are not enough.
+- `<key>=<value>`: in write mode (`-d`), forwarded as `--<key> <value>` to the provider CLI.
+- `<flag>`: in write mode (`-d`), forwarded as `--<flag>` to the provider CLI.
 
 ## Failure Handling
 

--- a/xurl-core/src/model.rs
+++ b/xurl-core/src/model.rs
@@ -58,9 +58,7 @@ pub struct WriteResult {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WriteOptions {
-    pub workdir: Option<PathBuf>,
-    pub add_dirs: Vec<PathBuf>,
-    pub passthrough: Vec<(String, Option<String>)>,
+    pub params: Vec<(String, Option<String>)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/xurl-core/src/provider/gemini.rs
+++ b/xurl-core/src/provider/gemini.rs
@@ -95,10 +95,7 @@ impl GeminiProvider {
         std::env::var("XURL_GEMINI_BIN").unwrap_or_else(|_| "gemini".to_string())
     }
 
-    fn spawn_gemini_command(
-        args: &[String],
-        workdir: Option<&Path>,
-    ) -> Result<std::process::Child> {
+    fn spawn_gemini_command(args: &[String]) -> Result<std::process::Child> {
         let bin = Self::gemini_bin();
         let mut command = Command::new(&bin);
         command
@@ -106,9 +103,6 @@ impl GeminiProvider {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        if let Some(workdir) = workdir {
-            command.current_dir(workdir);
-        }
         command.spawn().map_err(|source| {
             if source.kind() == std::io::ErrorKind::NotFound {
                 XurlError::CommandNotFound { command: bin }
@@ -128,7 +122,7 @@ impl GeminiProvider {
         sink: &mut dyn WriteEventSink,
         warnings: Vec<String>,
     ) -> Result<WriteResult> {
-        let mut child = Self::spawn_gemini_command(args, req.options.workdir.as_deref())?;
+        let mut child = Self::spawn_gemini_command(args)?;
         let stdout = child.stdout.take().ok_or_else(|| {
             XurlError::WriteProtocol("gemini stdout pipe is unavailable".to_string())
         })?;
@@ -286,31 +280,14 @@ impl Provider for GeminiProvider {
     }
 
     fn write(&self, req: &WriteRequest, sink: &mut dyn WriteEventSink) -> Result<WriteResult> {
-        let mut warnings = Vec::new();
+        let warnings = Vec::new();
         let mut args = vec![
             "-p".to_string(),
             req.prompt.clone(),
             "--output-format".to_string(),
             "stream-json".to_string(),
         ];
-        for dir in &req.options.add_dirs {
-            args.push("--include-directories".to_string());
-            args.push(dir.display().to_string());
-        }
-        append_passthrough_args(
-            &mut args,
-            &req.options.passthrough,
-            &[
-                "workdir",
-                "add_dir",
-                "output-format",
-                "prompt",
-                "p",
-                "resume",
-                "include-directories",
-            ],
-            &mut warnings,
-        );
+        append_passthrough_args(&mut args, &req.options.params);
         if let Some(session_id) = req.session_id.as_deref() {
             args.push("--resume".to_string());
             args.push(session_id.to_string());

--- a/xurl-core/src/provider/mod.rs
+++ b/xurl-core/src/provider/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 
@@ -14,33 +13,8 @@ pub mod gemini;
 pub mod opencode;
 pub mod pi;
 
-pub(crate) fn append_passthrough_args(
-    args: &mut Vec<String>,
-    passthrough: &[(String, Option<String>)],
-    ignored_keys: &[&str],
-    warnings: &mut Vec<String>,
-) {
-    let ignored = ignored_keys
-        .iter()
-        .map(|key| key.to_ascii_lowercase())
-        .collect::<HashSet<_>>();
-
-    for (key, value) in passthrough {
-        let normalized = key.trim().to_ascii_lowercase();
-        if normalized.is_empty() || normalized.starts_with('-') {
-            warnings.push(format!(
-                "ignored query parameter `{key}`: invalid flag name"
-            ));
-            continue;
-        }
-
-        if ignored.contains(&normalized) {
-            warnings.push(format!(
-                "ignored query parameter `{key}`: reserved by xurl for this provider"
-            ));
-            continue;
-        }
-
+pub(crate) fn append_passthrough_args(args: &mut Vec<String>, params: &[(String, Option<String>)]) {
+    for (key, value) in params {
         args.push(format!("--{key}"));
         if let Some(value) = value
             && !value.is_empty()


### PR DESCRIPTION
## Summary
- remove normalized `workdir` / `add_dir` handling from write options
- forward all URI query params directly as provider CLI flags in both create and append write modes
- remove provider-side reserved/ignored query filtering and workdir fallback cwd behavior
- update CLI integration tests and docs to match full passthrough behavior

## Verification
- cargo fmt
- cargo test
