### PR TITLE
feat: support skills:// for local and GitHub skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Read an agent conversation as markdown.
 - Query recent threads and keyword matches for a provider.
 - Discover subagent/branch navigation targets.
+- Read local and GitHub-hosted skills via `skills://` URIs.
 - Start a new conversation with agents.
 - Continue an existing conversation with follow-up prompts.
 
@@ -97,6 +98,24 @@ Save output:
 xurl -o /tmp/conversation.md agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592
 ```
 
+Read a local skill:
+
+```bash
+xurl skills://xurl
+```
+
+Read a GitHub skill:
+
+```bash
+xurl skills://github.com/Xuanwo/xurl/skills/xurl
+```
+
+Read skills frontmatter only:
+
+```bash
+xurl -I skills://xurl
+```
+
 ## Command Reference
 
 ```bash
@@ -109,8 +128,11 @@ xurl [OPTIONS] <URI>
   - file: `-d @prompt.txt`
   - stdin: `-d @-`
 - `-o, --output <PATH>`: write command output to file.
+- `-d, --data` is not supported for `skills://` URIs.
 
 ## URI Reference
+
+### Agents URI
 
 ```text
 [agents://]<provider>[/<conversation_id>[/<child_id>]][?<query>]
@@ -125,8 +147,7 @@ xurl [OPTIONS] <URI>
 - `child_id`: child/subagent identifier under a main conversation.
 - `query`: optional key-value parameters, interpreted by context.
 
-
-### Query
+### Agents Query
 
 - `q=<keyword>`: filters discovery results by keyword. Use when you want to find conversations by topic.
 - `limit=<n>`: limits discovery result count (default `10`). Use when you need a shorter or longer result list.
@@ -139,4 +160,11 @@ Examples:
 agents://codex?q=spawn_agent&limit=10
 agents://codex/threads/<conversation_id>
 agents://codex?cd=%2FUsers%2Falice%2Frepo&add-dir=%2FUsers%2Falice%2Fshared
+```
+
+### Skills URI
+
+```text
+skills://<skill_name>
+skills://github.com/<owner>/<repo>[/<skill_dir>]
 ```

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: xurl
-description: Use xurl to read, discover, and write AI agent conversations through agents:// URIs or shorthand provider paths.
+description: Use xurl to read, discover, and write AI agent conversations through agents:// URIs, and read skills through skills:// URIs.
 ---
 
 ## When to Use
 
 - User gives `agents://...` URI.
 - User gives shorthand URI like `codex/...` or `codex?...`.
+- User gives `skills://...` URI.
 - User asks to list/search provider threads.
 - User asks to read or summarize a conversation.
+- User asks to read local or GitHub-hosted skill content.
 - User asks to discover child targets before drill-down.
 - User asks to start or continue conversations for providers.
 
@@ -142,6 +144,26 @@ xurl agents://codex -d @prompt.txt
 cat prompt.md | xurl agents://claude -d @-
 ```
 
+### 5) Read Skills
+
+Read local skill:
+
+```bash
+xurl skills://xurl
+```
+
+Read GitHub skill:
+
+```bash
+xurl skills://github.com/Xuanwo/xurl/skills/xurl
+```
+
+Frontmatter only:
+
+```bash
+xurl -I skills://xurl
+```
+
 ## Command Reference
 
 - Base form: `xurl [OPTIONS] <URI>`
@@ -153,6 +175,7 @@ cat prompt.md | xurl agents://claude -d @-
 - `-o, --output`: write command output to file
 - `--head` and `--data` cannot be combined
 - multiple `-d` values are newline-joined
+- `--data` is not supported for `skills://` URIs
 
 ## URI Reference
 
@@ -180,6 +203,12 @@ Common URI patterns:
 - `agents://<provider>/<conversation_id>/<child_id>`: read child/subagent conversation
 - `agents://<provider>?k=v` with `-d`: create
 - `agents://<provider>/<conversation_id>` with `-d`: append
+
+Skills URI patterns:
+
+- `skills://<skill-name>`: read local skill from `~/.agents/skills/<skill-name>/SKILL.md`
+- `skills://github.com/<owner>/<repo>/<skill-dir>`: read remote skill from cloned cache
+- `skills://github.com/<owner>/<repo>`: auto-match skill; on ambiguity, `xurl` returns candidate URIs
 
 Query parameters:
 

--- a/xurl-cli/src/main.rs
+++ b/xurl-cli/src/main.rs
@@ -7,10 +7,11 @@ use std::io::{Read, Write};
 use clap::Parser;
 use xurl_core::uri::{is_uuid_session_id, parse_collection_query_uri};
 use xurl_core::{
-    AgentsUri, ProviderKind, ProviderRoots, WriteEventSink, WriteOptions, WriteRequest,
-    WriteResult, XurlError, query_threads, render_subagent_view_markdown,
-    render_thread_head_markdown, render_thread_markdown, render_thread_query_head_markdown,
-    render_thread_query_markdown, resolve_subagent_view, resolve_thread, write_thread,
+    AgentsUri, ProviderKind, ProviderRoots, SkillsUri, WriteEventSink, WriteOptions, WriteRequest,
+    WriteResult, XurlError, query_threads, render_skill_head_markdown, render_skill_markdown,
+    render_subagent_view_markdown, render_thread_head_markdown, render_thread_markdown,
+    render_thread_query_head_markdown, render_thread_query_markdown, resolve_skill,
+    resolve_subagent_view, resolve_thread, write_thread,
 };
 
 #[derive(Debug, Parser)]
@@ -53,7 +54,24 @@ fn run(cli: Cli) -> xurl_core::Result<()> {
     } = cli;
     let roots = ProviderRoots::from_env_or_home()?;
     let output = output.as_deref();
+    if uri.starts_with("skills://") && !data.is_empty() {
+        return Err(XurlError::InvalidMode(
+            "write mode (-d/--data) is not supported for skills:// URIs".to_string(),
+        ));
+    }
+
     if data.is_empty() {
+        if uri.starts_with("skills://") {
+            let skills_uri = SkillsUri::parse(&uri)?;
+            let resolved = resolve_skill(&skills_uri, &roots)?;
+            let output_body = if head {
+                render_skill_head_markdown(&resolved)
+            } else {
+                render_skill_markdown(&resolved)
+            };
+            return write_output(output, &output_body);
+        }
+
         if let Some(query) = parse_collection_query_uri(&uri)? {
             let result = query_threads(&query, &roots)?;
             let output_body = if head {
@@ -368,6 +386,17 @@ fn user_facing_error(err: &XurlError) -> String {
         XurlError::CommandFailed { command, .. } if command.contains("opencode") => format!(
             "{err}\nhint: verify OpenCode provider/model configuration and retry with `opencode run \"hello\" --format json`."
         ),
+        XurlError::SkillSelectionRequired { candidates, .. } => format!(
+            "{err}\nhint: choose one candidate URI and retry:\n{}",
+            candidates
+                .iter()
+                .map(|candidate| format!("- {candidate}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+        XurlError::SkillNotFound { .. } => {
+            format!("{err}\nhint: verify the skill name/path and retry the skills:// URI.")
+        }
         _ => err.to_string(),
     }
 }

--- a/xurl-cli/tests/cli.rs
+++ b/xurl-cli/tests/cli.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::{env, os::unix::fs::PermissionsExt};
 
@@ -472,6 +472,96 @@ fn pi_real_fixture_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pi_real_sanitized")
 }
 
+fn setup_local_skills_tree() -> tempfile::TempDir {
+    let temp = tempdir().expect("tempdir");
+    let skill_path = temp.path().join("skills/xurl/SKILL.md");
+    fs::create_dir_all(skill_path.parent().expect("parent")).expect("mkdir");
+    fs::write(
+        skill_path,
+        "---\nname: xurl\ndescription: local skill fixture\n---\n\n# xurl\n\nlocal fixture\n",
+    )
+    .expect("write");
+    temp
+}
+
+fn setup_github_skill_remote(
+    base: &Path,
+    owner: &str,
+    repo: &str,
+    files: &[(&str, &str)],
+) -> PathBuf {
+    let work = base.join("work");
+    fs::create_dir_all(&work).expect("mkdir work");
+    run_git_cmd(&["init".to_string(), path_arg(&work)], base);
+
+    for (relative, content) in files {
+        let path = work.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("mkdir file parent");
+        }
+        fs::write(path, content).expect("write fixture file");
+    }
+
+    run_git_cmd(
+        &[
+            "-C".to_string(),
+            path_arg(&work),
+            "add".to_string(),
+            ".".to_string(),
+        ],
+        base,
+    );
+    run_git_cmd(
+        &[
+            "-C".to_string(),
+            path_arg(&work),
+            "-c".to_string(),
+            "user.name=Test".to_string(),
+            "-c".to_string(),
+            "user.email=test@example.com".to_string(),
+            "commit".to_string(),
+            "-m".to_string(),
+            "init".to_string(),
+        ],
+        base,
+    );
+
+    let bare = base.join(owner).join(format!("{repo}.git"));
+    if let Some(parent) = bare.parent() {
+        fs::create_dir_all(parent).expect("mkdir bare parent");
+    }
+    run_git_cmd(
+        &[
+            "clone".to_string(),
+            "--bare".to_string(),
+            path_arg(&work),
+            path_arg(&bare),
+        ],
+        base,
+    );
+    bare
+}
+
+fn run_git_cmd(args: &[String], cwd: &Path) {
+    let output = std::process::Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("git command should run");
+    if !output.status.success() {
+        panic!(
+            "git command failed: {}\nstdout={}\nstderr={}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
 fn codex_uri() -> String {
     format!("codex://{SESSION_ID}")
 }
@@ -695,6 +785,111 @@ fn shorthand_uri_outputs_markdown() {
         )))
         .stdout(predicate::str::contains("## 1. User"))
         .stdout(predicate::str::contains("hello"));
+}
+
+#[test]
+fn skills_local_outputs_markdown() {
+    let temp = setup_local_skills_tree();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("XURL_SKILLS_ROOT", temp.path().join("skills"))
+        .arg("skills://xurl")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("name: xurl"))
+        .stdout(predicate::str::contains("# xurl"))
+        .stdout(predicate::str::contains("local fixture"));
+}
+
+#[test]
+fn skills_local_head_outputs_frontmatter() {
+    let temp = setup_local_skills_tree();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("XURL_SKILLS_ROOT", temp.path().join("skills"))
+        .arg("-I")
+        .arg("skills://xurl")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("kind: 'skill'"))
+        .stdout(predicate::str::contains("provider: 'skills'"))
+        .stdout(predicate::str::contains("source_kind: 'local'"))
+        .stdout(predicate::str::contains("source: '"))
+        .stdout(predicate::str::contains("resolved_path: 'xurl/SKILL.md'"));
+}
+
+#[test]
+fn skills_write_mode_is_rejected() {
+    let temp = setup_local_skills_tree();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("XURL_SKILLS_ROOT", temp.path().join("skills"))
+        .arg("skills://xurl")
+        .arg("-d")
+        .arg("hello")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "write mode (-d/--data) is not supported for skills:// URIs",
+        ));
+}
+
+#[test]
+fn skills_github_outputs_markdown() {
+    let temp = tempdir().expect("tempdir");
+    let remotes = temp.path().join("remotes");
+    setup_github_skill_remote(
+        &remotes,
+        "Xuanwo",
+        "xurl",
+        &[("skills/xurl/SKILL.md", "---\nname: xurl\n---\n\n# remote\n")],
+    );
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env(
+        "XURL_SKILLS_GITHUB_BASE_URL",
+        format!("file://{}", remotes.display()),
+    )
+    .env("XURL_SKILLS_CACHE_ROOT", temp.path().join("cache"))
+    .arg("skills://github.com/Xuanwo/xurl/skills/xurl")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("name: xurl"))
+    .stdout(predicate::str::contains("# remote"));
+}
+
+#[test]
+fn skills_github_reports_candidate_uris_when_ambiguous() {
+    let temp = tempdir().expect("tempdir");
+    let remotes = temp.path().join("remotes");
+    setup_github_skill_remote(
+        &remotes,
+        "Xuanwo",
+        "xurl",
+        &[
+            ("skills/first/SKILL.md", "# first\n"),
+            ("skills/second/SKILL.md", "# second\n"),
+        ],
+    );
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env(
+        "XURL_SKILLS_GITHUB_BASE_URL",
+        format!("file://{}", remotes.display()),
+    )
+    .env("XURL_SKILLS_CACHE_ROOT", temp.path().join("cache"))
+    .arg("skills://github.com/Xuanwo/xurl")
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains(
+        "choose one candidate URI and retry",
+    ))
+    .stderr(predicate::str::contains(
+        "skills://github.com/Xuanwo/xurl/skills/first",
+    ))
+    .stderr(predicate::str::contains(
+        "skills://github.com/Xuanwo/xurl/skills/second",
+    ));
 }
 
 #[test]

--- a/xurl-core/src/error.rs
+++ b/xurl-core/src/error.rs
@@ -10,6 +10,12 @@ pub enum XurlError {
     #[error("unsupported scheme: {0}")]
     UnsupportedScheme(String),
 
+    #[error("invalid skills uri: {0}")]
+    InvalidSkillsUri(String),
+
+    #[error("unsupported skills host: {0}")]
+    UnsupportedSkillsHost(String),
+
     #[error("invalid session id: {0}")]
     InvalidSessionId(String),
 
@@ -46,6 +52,28 @@ pub enum XurlError {
         provider: String,
         session_id: String,
         searched_roots: Vec<PathBuf>,
+    },
+
+    #[error("skill not found for uri={uri}")]
+    SkillNotFound { uri: String },
+
+    #[error("multiple skills matched for uri={uri}; choose one of: {candidates:?}")]
+    SkillSelectionRequired {
+        uri: String,
+        candidates: Vec<String>,
+    },
+
+    #[error("skill file is empty: {path}")]
+    EmptySkillFile { path: PathBuf },
+
+    #[error("skill file is not valid UTF-8: {path}")]
+    NonUtf8SkillFile { path: PathBuf },
+
+    #[error("git command failed: {command} (exit code: {code:?}): {stderr}")]
+    GitCommandFailed {
+        command: String,
+        code: Option<i32>,
+        stderr: String,
     },
 
     #[error("entry not found for provider={provider} session_id={session_id} entry_id={entry_id}")]

--- a/xurl-core/src/lib.rs
+++ b/xurl-core/src/lib.rs
@@ -8,14 +8,16 @@ pub mod uri;
 
 pub use error::{Result, XurlError};
 pub use model::{
-    MessageRole, PiEntryListView, ProviderKind, ResolutionMeta, ResolvedThread, SubagentDetailView,
-    SubagentListView, SubagentView, ThreadMessage, ThreadQuery, ThreadQueryItem, ThreadQueryResult,
-    WriteOptions, WriteRequest, WriteResult,
+    MessageRole, PiEntryListView, ProviderKind, ResolutionMeta, ResolvedSkill, ResolvedThread,
+    SkillResolutionMeta, SkillsSourceKind, SubagentDetailView, SubagentListView, SubagentView,
+    ThreadMessage, ThreadQuery, ThreadQueryItem, ThreadQueryResult, WriteOptions, WriteRequest,
+    WriteResult,
 };
 pub use provider::{ProviderRoots, WriteEventSink};
 pub use service::{
-    query_threads, render_subagent_view_markdown, render_thread_head_markdown,
-    render_thread_markdown, render_thread_query_head_markdown, render_thread_query_markdown,
+    query_threads, render_skill_head_markdown, render_skill_markdown,
+    render_subagent_view_markdown, render_thread_head_markdown, render_thread_markdown,
+    render_thread_query_head_markdown, render_thread_query_markdown, resolve_skill,
     resolve_subagent_view, resolve_thread, write_thread,
 };
-pub use uri::AgentsUri;
+pub use uri::{AgentsUri, SkillsUri};

--- a/xurl-core/src/model.rs
+++ b/xurl-core/src/model.rs
@@ -41,6 +41,39 @@ pub struct ResolvedThread {
     pub metadata: ResolutionMeta,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsSourceKind {
+    Local,
+    Github,
+}
+
+impl fmt::Display for SkillsSourceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Local => write!(f, "local"),
+            Self::Github => write!(f, "github"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SkillResolutionMeta {
+    pub warnings: Vec<String>,
+    pub candidates: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSkill {
+    pub uri: String,
+    pub source_kind: SkillsSourceKind,
+    pub skill_name: String,
+    pub source: String,
+    pub resolved_path: String,
+    pub content: String,
+    pub metadata: SkillResolutionMeta,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WriteRequest {
     pub prompt: String,

--- a/xurl-core/src/provider/mod.rs
+++ b/xurl-core/src/provider/mod.rs
@@ -12,6 +12,7 @@ pub mod codex;
 pub mod gemini;
 pub mod opencode;
 pub mod pi;
+pub mod skills;
 
 pub(crate) fn append_passthrough_args(args: &mut Vec<String>, params: &[(String, Option<String>)]) {
     for (key, value) in params {
@@ -46,6 +47,8 @@ pub struct ProviderRoots {
     pub gemini_root: PathBuf,
     pub pi_root: PathBuf,
     pub opencode_root: PathBuf,
+    pub skills_root: PathBuf,
+    pub skills_cache_root: PathBuf,
 }
 
 impl ProviderRoots {
@@ -100,6 +103,22 @@ impl ProviderRoots {
             .map(|path| path.join("opencode"))
             .unwrap_or_else(|| home.join(".local/share/opencode"));
 
+        // Precedence:
+        // 1) XURL_SKILLS_ROOT
+        // 2) ~/.agents/skills
+        let skills_root = env::var_os("XURL_SKILLS_ROOT")
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".agents/skills"));
+
+        // Precedence:
+        // 1) XURL_SKILLS_CACHE_ROOT
+        // 2) ~/.xurl/skills
+        let skills_cache_root = env::var_os("XURL_SKILLS_CACHE_ROOT")
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".xurl/skills"));
+
         Ok(Self {
             amp_root,
             codex_root,
@@ -107,6 +126,8 @@ impl ProviderRoots {
             gemini_root,
             pi_root,
             opencode_root,
+            skills_root,
+            skills_cache_root,
         })
     }
 }

--- a/xurl-core/src/provider/skills.rs
+++ b/xurl-core/src/provider/skills.rs
@@ -1,0 +1,512 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use walkdir::WalkDir;
+
+use crate::error::{Result, XurlError};
+use crate::model::{ResolvedSkill, SkillResolutionMeta, SkillsSourceKind};
+use crate::uri::SkillsUri;
+
+#[derive(Debug, Clone)]
+pub struct SkillsProvider {
+    root: PathBuf,
+    cache_root: PathBuf,
+    github_base_url: Option<String>,
+}
+
+impl SkillsProvider {
+    pub fn new(root: impl Into<PathBuf>, cache_root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            cache_root: cache_root.into(),
+            github_base_url: std::env::var("XURL_SKILLS_GITHUB_BASE_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty()),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_github_base_url(mut self, github_base_url: impl Into<String>) -> Self {
+        self.github_base_url = Some(github_base_url.into());
+        self
+    }
+
+    pub fn resolve(&self, uri: &SkillsUri) -> Result<ResolvedSkill> {
+        match uri {
+            SkillsUri::Local { skill_name } => self.resolve_local(uri, skill_name),
+            SkillsUri::Github {
+                owner,
+                repo,
+                skill_path,
+            } => self.resolve_github(uri, owner, repo, skill_path.as_deref()),
+        }
+    }
+
+    fn resolve_local(&self, uri: &SkillsUri, skill_name: &str) -> Result<ResolvedSkill> {
+        let path = self.root.join(skill_name).join("SKILL.md");
+        if !path.exists() {
+            return Err(XurlError::SkillNotFound {
+                uri: uri.as_string(),
+            });
+        }
+
+        let content = read_skill_file(&path)?;
+
+        Ok(ResolvedSkill {
+            uri: uri.as_string(),
+            source_kind: SkillsSourceKind::Local,
+            skill_name: skill_name.to_string(),
+            source: path.display().to_string(),
+            resolved_path: format!("{skill_name}/SKILL.md"),
+            content,
+            metadata: SkillResolutionMeta::default(),
+        })
+    }
+
+    fn resolve_github(
+        &self,
+        uri: &SkillsUri,
+        owner: &str,
+        repo: &str,
+        skill_path: Option<&str>,
+    ) -> Result<ResolvedSkill> {
+        fs::create_dir_all(&self.cache_root).map_err(|source| XurlError::Io {
+            path: self.cache_root.clone(),
+            source,
+        })?;
+
+        let repo_dir = self.cache_root.join(cache_dir_name(owner, repo));
+        let remote_url = self.github_remote_url(owner, repo);
+        self.sync_repo(&repo_dir, &remote_url)?;
+
+        if let Some(skill_path) = skill_path {
+            let relative_skill_file = normalize_skill_file_path(skill_path)
+                .ok_or_else(|| XurlError::InvalidSkillsUri(uri.as_string()))?;
+            return self.resolve_github_from_relative(uri, repo, &repo_dir, &relative_skill_file);
+        }
+
+        for candidate in [
+            PathBuf::from("SKILL.md"),
+            PathBuf::from("skills").join(repo).join("SKILL.md"),
+        ] {
+            let absolute = repo_dir.join(&candidate);
+            if absolute.exists() {
+                return self.resolve_github_from_relative(uri, repo, &repo_dir, &candidate);
+            }
+        }
+
+        let candidates = collect_skill_candidates(&repo_dir)?;
+        match candidates.as_slice() {
+            [] => Err(XurlError::SkillNotFound {
+                uri: uri.as_string(),
+            }),
+            [candidate] => {
+                self.resolve_github_from_relative(uri, repo, &repo_dir, Path::new(candidate))
+            }
+            _ => Err(XurlError::SkillSelectionRequired {
+                uri: uri.as_string(),
+                candidates: candidates
+                    .iter()
+                    .map(|candidate| candidate_to_uri(owner, repo, candidate))
+                    .collect(),
+            }),
+        }
+    }
+
+    fn resolve_github_from_relative(
+        &self,
+        uri: &SkillsUri,
+        repo: &str,
+        repo_dir: &Path,
+        relative_skill_file: &Path,
+    ) -> Result<ResolvedSkill> {
+        let absolute_skill_file = repo_dir.join(relative_skill_file);
+        if !absolute_skill_file.exists() {
+            return Err(XurlError::SkillNotFound {
+                uri: uri.as_string(),
+            });
+        }
+
+        let content = read_skill_file(&absolute_skill_file)?;
+        let relative = relative_skill_file.to_string_lossy().replace('\\', "/");
+
+        Ok(ResolvedSkill {
+            uri: uri.as_string(),
+            source_kind: SkillsSourceKind::Github,
+            skill_name: skill_name_from_relative(repo, &relative),
+            source: absolute_skill_file.display().to_string(),
+            resolved_path: relative,
+            content,
+            metadata: SkillResolutionMeta::default(),
+        })
+    }
+
+    fn github_remote_url(&self, owner: &str, repo: &str) -> String {
+        if let Some(base) = &self.github_base_url {
+            return format!("{}/{owner}/{repo}.git", base.trim_end_matches('/'),);
+        }
+
+        format!("https://github.com/{owner}/{repo}.git")
+    }
+
+    fn sync_repo(&self, repo_dir: &Path, remote_url: &str) -> Result<()> {
+        if repo_dir.join(".git").exists() {
+            run_git(
+                [
+                    OsStr::new("-C"),
+                    repo_dir.as_os_str(),
+                    OsStr::new("fetch"),
+                    OsStr::new("--depth=1"),
+                    OsStr::new("origin"),
+                ],
+                &self.cache_root,
+            )?;
+            run_git(
+                [
+                    OsStr::new("-C"),
+                    repo_dir.as_os_str(),
+                    OsStr::new("reset"),
+                    OsStr::new("--hard"),
+                    OsStr::new("FETCH_HEAD"),
+                ],
+                &self.cache_root,
+            )?;
+            return Ok(());
+        }
+
+        if repo_dir.exists() {
+            return Err(XurlError::InvalidMode(format!(
+                "skills cache path exists but is not a git repository: {}",
+                repo_dir.display()
+            )));
+        }
+
+        if let Some(parent) = repo_dir.parent() {
+            fs::create_dir_all(parent).map_err(|source| XurlError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        run_git(
+            [
+                OsStr::new("clone"),
+                OsStr::new("--filter=blob:none"),
+                OsStr::new("--depth=1"),
+                OsStr::new(remote_url),
+                repo_dir.as_os_str(),
+            ],
+            &self.cache_root,
+        )?;
+
+        Ok(())
+    }
+}
+
+fn read_skill_file(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).map_err(|source| XurlError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    if bytes.is_empty() {
+        return Err(XurlError::EmptySkillFile {
+            path: path.to_path_buf(),
+        });
+    }
+
+    String::from_utf8(bytes).map_err(|_| XurlError::NonUtf8SkillFile {
+        path: path.to_path_buf(),
+    })
+}
+
+fn run_git<const N: usize>(args: [&OsStr; N], cwd: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                XurlError::CommandNotFound {
+                    command: "git".to_string(),
+                }
+            } else {
+                XurlError::Io {
+                    path: PathBuf::from("git"),
+                    source,
+                }
+            }
+        })?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+    }
+
+    let command = format!(
+        "git {}",
+        args.iter()
+            .map(|item| item.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Err(XurlError::GitCommandFailed {
+        command,
+        code: output.status.code(),
+        stderr,
+    })
+}
+
+fn normalize_skill_file_path(path: &str) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for segment in path.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." || segment.contains('\\') {
+            return None;
+        }
+        normalized.push(segment);
+    }
+
+    let ends_with_skill_file = normalized
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "SKILL.md");
+    if !ends_with_skill_file {
+        normalized.push("SKILL.md");
+    }
+
+    Some(normalized)
+}
+
+fn skill_name_from_relative(repo: &str, relative_skill_file: &str) -> String {
+    let path = Path::new(relative_skill_file);
+    let parent = path.parent().and_then(Path::to_str).unwrap_or_default();
+    if parent.is_empty() || parent == "." {
+        return repo.to_string();
+    }
+
+    Path::new(parent)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| repo.to_string())
+}
+
+fn collect_skill_candidates(repo_dir: &Path) -> Result<Vec<String>> {
+    let mut candidates = Vec::new();
+
+    for entry in WalkDir::new(repo_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|entry| entry.file_name() != ".git")
+        .filter_map(std::result::Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name() != "SKILL.md" {
+            continue;
+        }
+
+        let relative = entry
+            .path()
+            .strip_prefix(repo_dir)
+            .map_err(|_| {
+                XurlError::InvalidMode("failed to strip skill candidate prefix".to_string())
+            })?
+            .to_string_lossy()
+            .replace('\\', "/");
+        candidates.push(relative);
+    }
+
+    candidates.sort();
+    candidates.dedup();
+    Ok(candidates)
+}
+
+fn cache_dir_name(owner: &str, repo: &str) -> String {
+    fn sanitize(value: &str) -> String {
+        value
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() {
+                    ch.to_ascii_lowercase()
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>()
+    }
+
+    format!("github-com-{}-{}", sanitize(owner), sanitize(repo))
+}
+
+fn candidate_to_uri(owner: &str, repo: &str, relative_skill_file: &str) -> String {
+    let path = Path::new(relative_skill_file);
+    let parent = path.parent().and_then(Path::to_str).unwrap_or_default();
+    if parent.is_empty() || parent == "." {
+        format!("skills://github.com/{owner}/{repo}")
+    } else {
+        format!("skills://github.com/{owner}/{repo}/{parent}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    use super::SkillsProvider;
+    use crate::error::XurlError;
+    use crate::uri::SkillsUri;
+
+    #[test]
+    fn resolve_local_skill_success() {
+        let dir = tempdir().expect("tempdir");
+        let skill_dir = dir.path().join("skills/xurl");
+        fs::create_dir_all(&skill_dir).expect("mkdir");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: xurl\ndescription: test\n---\n\n# xurl\n",
+        )
+        .expect("write");
+
+        let provider = SkillsProvider::new(dir.path().join("skills"), dir.path().join("cache"));
+        let resolved = provider
+            .resolve(&SkillsUri::parse("skills://xurl").expect("parse"))
+            .expect("resolve");
+
+        assert_eq!(resolved.skill_name, "xurl");
+        assert!(resolved.content.contains("name: xurl"));
+        assert_eq!(resolved.resolved_path, "xurl/SKILL.md");
+    }
+
+    #[test]
+    fn resolve_local_skill_not_found() {
+        let dir = tempdir().expect("tempdir");
+        let provider = SkillsProvider::new(dir.path().join("skills"), dir.path().join("cache"));
+
+        let err = provider
+            .resolve(&SkillsUri::parse("skills://missing").expect("parse"))
+            .expect_err("must fail");
+        assert!(matches!(err, XurlError::SkillNotFound { .. }));
+    }
+
+    #[test]
+    fn resolve_github_skill_by_path() {
+        let dir = tempdir().expect("tempdir");
+        let remotes = dir.path().join("remotes");
+        create_git_remote(
+            &remotes,
+            "Xuanwo",
+            "xurl",
+            &[('s', "skills/xurl/SKILL.md", "# xurl\n")],
+        );
+
+        let provider = SkillsProvider::new(dir.path().join("local"), dir.path().join("cache"))
+            .with_github_base_url(format!("file://{}", remotes.display()));
+
+        let resolved = provider
+            .resolve(
+                &SkillsUri::parse("skills://github.com/Xuanwo/xurl/skills/xurl").expect("parse"),
+            )
+            .expect("resolve");
+
+        assert_eq!(resolved.skill_name, "xurl");
+        assert_eq!(resolved.resolved_path, "skills/xurl/SKILL.md");
+        assert!(resolved.content.contains("# xurl"));
+    }
+
+    #[test]
+    fn resolve_github_skill_reports_candidates() {
+        let dir = tempdir().expect("tempdir");
+        let remotes = dir.path().join("remotes");
+        create_git_remote(
+            &remotes,
+            "Xuanwo",
+            "xurl",
+            &[
+                ('a', "skills/first/SKILL.md", "# first\n"),
+                ('b', "skills/second/SKILL.md", "# second\n"),
+            ],
+        );
+
+        let provider = SkillsProvider::new(dir.path().join("local"), dir.path().join("cache"))
+            .with_github_base_url(format!("file://{}", remotes.display()));
+
+        let err = provider
+            .resolve(&SkillsUri::parse("skills://github.com/Xuanwo/xurl").expect("parse"))
+            .expect_err("must fail");
+
+        match err {
+            XurlError::SkillSelectionRequired { candidates, .. } => {
+                assert_eq!(candidates.len(), 2);
+                assert!(candidates[0].starts_with("skills://github.com/Xuanwo/xurl/"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    fn create_git_remote(base: &Path, owner: &str, repo: &str, files: &[(char, &str, &str)]) {
+        let work = base.join("work");
+        fs::create_dir_all(&work).expect("mkdir work");
+        run_git(["init", work.to_str().expect("path")], base);
+
+        for (_, relative, content) in files {
+            let path = work.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("mkdir file parent");
+            }
+            fs::write(path, content).expect("write file");
+        }
+
+        run_git(["-C", work.to_str().expect("path"), "add", "."], base);
+        run_git(
+            [
+                "-C",
+                work.to_str().expect("path"),
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "init",
+            ],
+            base,
+        );
+
+        let bare = base.join(owner).join(format!("{repo}.git"));
+        if let Some(parent) = bare.parent() {
+            fs::create_dir_all(parent).expect("mkdir bare parent");
+        }
+        run_git(
+            [
+                "clone",
+                "--bare",
+                work.to_str().expect("path"),
+                bare.to_str().expect("path"),
+            ],
+            base,
+        );
+    }
+
+    fn run_git<const N: usize>(args: [&str; N], cwd: &Path) {
+        let output = std::process::Command::new("git")
+            .current_dir(cwd)
+            .args(args)
+            .output()
+            .expect("git command should run");
+        if !output.status.success() {
+            panic!(
+                "git command failed: {}\nstdout={}\nstderr={}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+    }
+}

--- a/xurl-core/src/service.rs
+++ b/xurl-core/src/service.rs
@@ -15,10 +15,10 @@ use walkdir::WalkDir;
 use crate::error::{Result, XurlError};
 use crate::jsonl;
 use crate::model::{
-    MessageRole, PiEntryListItem, PiEntryListView, PiEntryQuery, ProviderKind, ResolvedThread,
-    SubagentDetailView, SubagentExcerptMessage, SubagentLifecycleEvent, SubagentListItem,
-    SubagentListView, SubagentQuery, SubagentRelation, SubagentThreadRef, SubagentView,
-    ThreadQuery, ThreadQueryItem, ThreadQueryResult, WriteRequest, WriteResult,
+    MessageRole, PiEntryListItem, PiEntryListView, PiEntryQuery, ProviderKind, ResolvedSkill,
+    ResolvedThread, SubagentDetailView, SubagentExcerptMessage, SubagentLifecycleEvent,
+    SubagentListItem, SubagentListView, SubagentQuery, SubagentRelation, SubagentThreadRef,
+    SubagentView, ThreadQuery, ThreadQueryItem, ThreadQueryResult, WriteRequest, WriteResult,
 };
 use crate::provider::amp::AmpProvider;
 use crate::provider::claude::ClaudeProvider;
@@ -26,9 +26,10 @@ use crate::provider::codex::CodexProvider;
 use crate::provider::gemini::GeminiProvider;
 use crate::provider::opencode::OpencodeProvider;
 use crate::provider::pi::PiProvider;
+use crate::provider::skills::SkillsProvider;
 use crate::provider::{Provider, ProviderRoots, WriteEventSink};
 use crate::render;
-use crate::uri::{AgentsUri, is_uuid_session_id};
+use crate::uri::{AgentsUri, SkillsUri, is_uuid_session_id};
 
 const STATUS_PENDING_INIT: &str = "pendingInit";
 const STATUS_RUNNING: &str = "running";
@@ -171,6 +172,10 @@ pub fn resolve_thread(uri: &AgentsUri, roots: &ProviderRoots) -> Result<Resolved
         ProviderKind::Pi => PiProvider::new(&roots.pi_root).resolve(session_id),
         ProviderKind::Opencode => OpencodeProvider::new(&roots.opencode_root).resolve(session_id),
     }
+}
+
+pub fn resolve_skill(uri: &SkillsUri, roots: &ProviderRoots) -> Result<ResolvedSkill> {
+    SkillsProvider::new(&roots.skills_root, &roots.skills_cache_root).resolve(uri)
 }
 
 pub fn write_thread(
@@ -423,6 +428,35 @@ pub fn render_thread_markdown(uri: &AgentsUri, resolved: &ResolvedThread) -> Res
     let raw = read_thread_raw(&resolved.path)?;
     let markdown = render::render_markdown(uri, &resolved.path, &raw)?;
     Ok(strip_frontmatter(markdown))
+}
+
+pub fn render_skill_markdown(resolved: &ResolvedSkill) -> String {
+    resolved.content.clone()
+}
+
+pub fn render_skill_head_markdown(resolved: &ResolvedSkill) -> String {
+    let mut output = String::new();
+    output.push_str("---\n");
+    push_yaml_string(&mut output, "uri", &resolved.uri);
+    push_yaml_string(&mut output, "kind", "skill");
+    push_yaml_string(&mut output, "provider", "skills");
+    push_yaml_string(
+        &mut output,
+        "source_kind",
+        &resolved.source_kind.to_string(),
+    );
+    push_yaml_string(&mut output, "skill_name", &resolved.skill_name);
+    push_yaml_string(&mut output, "source", &resolved.source);
+    push_yaml_string(&mut output, "resolved_path", &resolved.resolved_path);
+    render_warnings(&mut output, &resolved.metadata.warnings);
+    if !resolved.metadata.candidates.is_empty() {
+        output.push_str("candidates:\n");
+        for candidate in &resolved.metadata.candidates {
+            output.push_str(&format!("  - '{}'\n", yaml_single_quoted(candidate)));
+        }
+    }
+    output.push_str("---\n");
+    output
 }
 
 pub fn render_thread_head_markdown(uri: &AgentsUri, roots: &ProviderRoots) -> Result<String> {

--- a/xurl-core/src/uri.rs
+++ b/xurl-core/src/uri.rs
@@ -24,6 +24,119 @@ pub fn is_uuid_session_id(input: &str) -> bool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillsUri {
+    Local {
+        skill_name: String,
+    },
+    Github {
+        owner: String,
+        repo: String,
+        skill_path: Option<String>,
+    },
+}
+
+impl SkillsUri {
+    pub fn parse(input: &str) -> Result<Self> {
+        input.parse()
+    }
+
+    pub fn as_string(&self) -> String {
+        match self {
+            Self::Local { skill_name } => format!("skills://{skill_name}"),
+            Self::Github {
+                owner,
+                repo,
+                skill_path,
+            } => {
+                if let Some(skill_path) = skill_path {
+                    format!("skills://github.com/{owner}/{repo}/{skill_path}")
+                } else {
+                    format!("skills://github.com/{owner}/{repo}")
+                }
+            }
+        }
+    }
+}
+
+impl FromStr for SkillsUri {
+    type Err = XurlError;
+
+    fn from_str(input: &str) -> Result<Self> {
+        let target_with_query = input
+            .strip_prefix("skills://")
+            .ok_or_else(|| XurlError::InvalidSkillsUri(input.to_string()))?;
+
+        let (target, raw_query) = split_target_and_query(target_with_query);
+        if raw_query.is_some_and(|query| !query.is_empty()) {
+            return Err(XurlError::InvalidSkillsUri(format!(
+                "{input} (query parameters are not supported)"
+            )));
+        }
+
+        if target.is_empty() {
+            return Err(XurlError::InvalidSkillsUri(input.to_string()));
+        }
+
+        if !target.contains('/') {
+            validate_skills_segment(target, input)?;
+            return Ok(Self::Local {
+                skill_name: target.to_string(),
+            });
+        }
+
+        let mut segments = target.split('/');
+        let host = segments.next().unwrap_or_default();
+        if host.is_empty() {
+            return Err(XurlError::InvalidSkillsUri(input.to_string()));
+        }
+        if host != "github.com" {
+            return Err(XurlError::UnsupportedSkillsHost(host.to_string()));
+        }
+
+        let owner = segments
+            .next()
+            .ok_or_else(|| XurlError::InvalidSkillsUri(input.to_string()))?;
+        let repo = segments
+            .next()
+            .ok_or_else(|| XurlError::InvalidSkillsUri(input.to_string()))?;
+        validate_skills_segment(owner, input)?;
+        validate_skills_segment(repo, input)?;
+
+        let remaining = segments.collect::<Vec<_>>();
+        if remaining.iter().any(|segment| segment.is_empty()) {
+            return Err(XurlError::InvalidSkillsUri(input.to_string()));
+        }
+        for segment in &remaining {
+            validate_skills_segment(segment, input)?;
+        }
+
+        let skill_path = if remaining.is_empty() {
+            None
+        } else {
+            Some(remaining.join("/"))
+        };
+
+        Ok(Self::Github {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            skill_path,
+        })
+    }
+}
+
+fn validate_skills_segment(segment: &str, input: &str) -> Result<()> {
+    if segment.is_empty()
+        || segment == "."
+        || segment == ".."
+        || segment.contains('\\')
+        || segment.contains(':')
+    {
+        return Err(XurlError::InvalidSkillsUri(input.to_string()));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentsUri {
     pub provider: ProviderKind,
     pub session_id: String,
@@ -421,8 +534,69 @@ fn hex_nibble(value: u8) -> Option<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentsUri, parse_collection_query_uri};
+    use super::{AgentsUri, SkillsUri, parse_collection_query_uri};
     use crate::model::ProviderKind;
+
+    #[test]
+    fn parse_local_skills_uri() {
+        let uri = SkillsUri::parse("skills://xurl").expect("parse should succeed");
+        assert_eq!(
+            uri,
+            SkillsUri::Local {
+                skill_name: "xurl".to_string(),
+            }
+        );
+        assert_eq!(uri.as_string(), "skills://xurl");
+    }
+
+    #[test]
+    fn parse_github_skills_uri() {
+        let uri = SkillsUri::parse("skills://github.com/Xuanwo/xurl").expect("parse should work");
+        assert_eq!(
+            uri,
+            SkillsUri::Github {
+                owner: "Xuanwo".to_string(),
+                repo: "xurl".to_string(),
+                skill_path: None,
+            }
+        );
+        assert_eq!(uri.as_string(), "skills://github.com/Xuanwo/xurl");
+    }
+
+    #[test]
+    fn parse_github_skills_uri_with_path() {
+        let uri = SkillsUri::parse("skills://github.com/Xuanwo/xurl/skills/xurl")
+            .expect("parse should work");
+        assert_eq!(
+            uri,
+            SkillsUri::Github {
+                owner: "Xuanwo".to_string(),
+                repo: "xurl".to_string(),
+                skill_path: Some("skills/xurl".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_skills_query_parameters() {
+        let err =
+            SkillsUri::parse("skills://github.com/Xuanwo/xurl?ref=main").expect_err("must fail");
+        assert!(format!("{err}").contains("query parameters are not supported"));
+    }
+
+    #[test]
+    fn parse_rejects_skills_unsupported_host() {
+        let err =
+            SkillsUri::parse("skills://gitlab.com/Xuanwo/xurl").expect_err("must reject host");
+        assert!(format!("{err}").contains("unsupported skills host"));
+    }
+
+    #[test]
+    fn parse_rejects_skills_path_traversal() {
+        let err = SkillsUri::parse("skills://github.com/Xuanwo/xurl/../evil")
+            .expect_err("must reject traversal");
+        assert!(format!("{err}").contains("invalid skills uri"));
+    }
 
     #[test]
     fn parse_valid_uri() {


### PR DESCRIPTION
## Summary

This PR adds full `skills://` read support to xurl with both local and GitHub-backed skill loading.

### What is included

- Add `SkillsUri` parsing for:
  - `skills://<skill-name>`
  - `skills://github.com/<owner>/<repo>`
  - `skills://github.com/<owner>/<repo>/<skill-path>`
- Add skill resolution model and error types (`SkillNotFound`, `SkillSelectionRequired`, `GitCommandFailed`, etc.).
- Add a new skills provider:
  - local skill loading from `~/.agents/skills` (or `XURL_SKILLS_ROOT`)
  - GitHub repo caching under `~/.xurl/skills` (or `XURL_SKILLS_CACHE_ROOT`)
  - clone/fetch/reset workflow for remote sync
  - candidate URI suggestions when multiple skills are found
- Add service-level skill rendering:
  - `render_skill_markdown`
  - `render_skill_head_markdown`
- Update CLI routing:
  - read-mode support for `skills://`
  - reject write mode (`-d/--data`) for `skills://`
  - improved user-facing hints for skill selection and not-found cases
- Update docs:
  - `README.md`
  - `skills/xurl/SKILL.md`
- Add tests:
  - URI parsing tests for `SkillsUri`
  - core provider tests for local/GitHub/candidate selection
  - CLI integration tests for local and GitHub skills

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets`
- `cargo test`

All passed.
