### PR TITLE
ci: publish only wheel artifacts to PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -101,12 +101,6 @@ jobs:
             --vendor-src dist/vendor \
             --output-dir dist/pypi
 
-      - name: Stage source distribution
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist/pypi
-
       - name: Upload PyPI distributions
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- remove PyPI sdist staging step from the publish workflow
- keep PyPI publishing focused on prebuilt wheel artifacts only

## Validation
- parsed `.github/workflows/pypi-publish.yml` as YAML locally
