### PR TITLE
feat: native agent role support for agents:// URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +816,45 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "unicode-ident"
@@ -934,6 +982,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1100,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "walkdir",
 ]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - Read an agent conversation as markdown.
 - Query recent threads and keyword matches for a provider.
+- Query role-scoped threads with `agents://<provider>/<role>`.
 - Discover subagent/branch navigation targets.
 - Read local and GitHub-hosted skills via `skills://` URIs.
 - Start a new conversation with agents.
@@ -30,14 +31,14 @@ Please summarize this thread: agents://codex/xxx_thread
 
 ## Providers
 
-| Provider | Query | Create |
-| --- | --- | --- |
-| <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp | Yes | Yes |
-| <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex | Yes | Yes |
-| <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude | Yes | Yes |
-| <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini | Yes | Yes |
-| <img src=".github/assets/pi-logo-dark.svg" alt="Pi logo" width="16" height="16" /> Pi | Yes | Yes |
-| <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode | Yes | Yes |
+| Provider | Query | Create | Role Create |
+| --- | --- | --- | --- |
+| <img src="https://ampcode.com/amp-mark-color.svg" alt="Amp logo" width="16" height="16" /> Amp | Yes | Yes | No |
+| <img src="https://avatars.githubusercontent.com/u/14957082?s=24&v=4" alt="Codex logo" width="16" height="16" /> Codex | Yes | Yes | Yes |
+| <img src="https://www.anthropic.com/favicon.ico" alt="Claude logo" width="16" height="16" /> Claude | Yes | Yes | Yes |
+| <img src="https://www.google.com/favicon.ico" alt="Gemini logo" width="16" height="16" /> Gemini | Yes | Yes | No |
+| <img src=".github/assets/pi-logo-dark.svg" alt="Pi logo" width="16" height="16" /> Pi | Yes | Yes | No |
+| <img src="https://opencode.ai/favicon.ico" alt="OpenCode logo" width="16" height="16" /> OpenCode | Yes | Yes | Yes |
 
 ## Usage
 
@@ -60,6 +61,14 @@ xurl codex
 xurl 'codex?q=spawn_agent'
 ```
 
+Query role-scoped threads:
+
+```bash
+xurl agents://codex/reviewer
+# equivalent shorthand:
+xurl codex/reviewer
+```
+
 Discover child targets:
 
 ```bash
@@ -78,6 +87,12 @@ Start a new agent conversation:
 xurl agents://codex -d "Draft a migration plan"
 # equivalent shorthand:
 xurl codex -d "Draft a migration plan"
+```
+
+Start a new conversation with role URI:
+
+```bash
+xurl agents://codex/reviewer -d "Review this patch"
 ```
 
 Continue an existing conversation:
@@ -135,7 +150,7 @@ xurl [OPTIONS] <URI>
 ### Agents URI
 
 ```text
-[agents://]<provider>[/<conversation_id>[/<child_id>]][?<query>]
+[agents://]<provider>[/<token>[/<child_id>]][?<query>]
 |------|  |--------|  |---------------------------|  |------|
  optional   provider         optional path parts        query
  scheme
@@ -143,7 +158,7 @@ xurl [OPTIONS] <URI>
 
 - `scheme`: optional `agents://` prefix. If omitted, `xurl` treats input as an `agents` URI shorthand.
 - `provider`: target provider name, such as `codex`, `claude`, `gemini`, `amp`, `pi`, `opencode`.
-- `conversation_id`: main conversation identifier.
+- `token`: main conversation identifier or role name.
 - `child_id`: child/subagent identifier under a main conversation.
 - `query`: optional key-value parameters, interpreted by context.
 
@@ -159,6 +174,7 @@ Examples:
 ```text
 agents://codex?q=spawn_agent&limit=10
 agents://codex/threads/<conversation_id>
+agents://codex/reviewer
 agents://codex?cd=%2FUsers%2Falice%2Frepo&add-dir=%2FUsers%2Falice%2Fshared
 ```
 

--- a/xurl-core/Cargo.toml
+++ b/xurl-core/Cargo.toml
@@ -12,6 +12,7 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
+toml = "0.9.8"
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/xurl-core/src/model.rs
+++ b/xurl-core/src/model.rs
@@ -92,6 +92,7 @@ pub struct WriteResult {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WriteOptions {
     pub params: Vec<(String, Option<String>)>,
+    pub role: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -216,6 +217,7 @@ pub struct PiEntryListView {
 pub struct ThreadQuery {
     pub uri: String,
     pub provider: ProviderKind,
+    pub role: Option<String>,
     pub q: Option<String>,
     pub limit: usize,
     pub ignored_params: Vec<String>,

--- a/xurl-core/src/provider/amp.rs
+++ b/xurl-core/src/provider/amp.rs
@@ -216,6 +216,12 @@ impl Provider for AmpProvider {
     }
 
     fn write(&self, req: &WriteRequest, sink: &mut dyn WriteEventSink) -> Result<WriteResult> {
+        if let Some(role) = req.options.role.as_deref() {
+            return Err(XurlError::InvalidMode(format!(
+                "provider `{}` does not support role-based write URI (`{role}`) in non-interactive mode",
+                ProviderKind::Amp
+            )));
+        }
         let warnings = Vec::new();
         let mut args = Vec::new();
         if let Some(session_id) = req.session_id.as_deref() {

--- a/xurl-core/src/provider/gemini.rs
+++ b/xurl-core/src/provider/gemini.rs
@@ -280,6 +280,12 @@ impl Provider for GeminiProvider {
     }
 
     fn write(&self, req: &WriteRequest, sink: &mut dyn WriteEventSink) -> Result<WriteResult> {
+        if let Some(role) = req.options.role.as_deref() {
+            return Err(XurlError::InvalidMode(format!(
+                "provider `{}` does not support role-based write URI (`{role}`) in non-interactive mode",
+                ProviderKind::Gemini
+            )));
+        }
         let warnings = Vec::new();
         let mut args = vec![
             "-p".to_string(),

--- a/xurl-core/src/provider/mod.rs
+++ b/xurl-core/src/provider/mod.rs
@@ -15,7 +15,20 @@ pub mod pi;
 pub mod skills;
 
 pub(crate) fn append_passthrough_args(args: &mut Vec<String>, params: &[(String, Option<String>)]) {
+    append_passthrough_args_excluding(args, params, &[]);
+}
+
+pub(crate) fn append_passthrough_args_excluding(
+    args: &mut Vec<String>,
+    params: &[(String, Option<String>)],
+    excluded_keys: &[&str],
+) -> Vec<String> {
+    let mut excluded = Vec::new();
     for (key, value) in params {
+        if excluded_keys.iter().any(|candidate| candidate == key) {
+            excluded.push(key.clone());
+            continue;
+        }
         args.push(format!("--{key}"));
         if let Some(value) = value
             && !value.is_empty()
@@ -23,6 +36,7 @@ pub(crate) fn append_passthrough_args(args: &mut Vec<String>, params: &[(String,
             args.push(value.clone());
         }
     }
+    excluded
 }
 
 pub trait WriteEventSink {

--- a/xurl-core/src/provider/pi.rs
+++ b/xurl-core/src/provider/pi.rs
@@ -293,6 +293,12 @@ impl Provider for PiProvider {
     }
 
     fn write(&self, req: &WriteRequest, sink: &mut dyn WriteEventSink) -> Result<WriteResult> {
+        if let Some(role) = req.options.role.as_deref() {
+            return Err(XurlError::InvalidMode(format!(
+                "provider `{}` does not support role-based write URI (`{role}`)",
+                ProviderKind::Pi
+            )));
+        }
         let warnings = Vec::new();
         let mut args = Vec::new();
         if let Some(session_id) = req.session_id.as_deref() {


### PR DESCRIPTION
## Summary
- add session-first, role-fallback parsing for `agents://<provider>/<token>` in read/write flows
- support role-scoped thread query via `agents://<provider>/<role>`
- extend write options with `role` and wire provider-specific role behavior
- add provider role handling:
  - codex: load `[agents.<role>]` (and optional `config_file`) from `~/.codex/config.toml`, map to `--config`
  - claude/opencode: pass `--agent <role>`
  - amp/gemini/pi: return explicit non-interactive role-write error
- add CLI and core tests for role query/create paths and documentation sync in README + skill doc

## Testing
- `cargo test`
  - total: `171 passed, 0 failed`
