### PR TITLE
Add meta=1 expansion for thread queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ Query provider threads:
 xurl agents://codex
 xurl 'agents://codex?q=spawn_agent'
 xurl 'agents://claude?q=agent&limit=5'
+xurl 'agents://codex?limit=5&meta=1'
 # equivalent shorthand:
 xurl codex
 xurl 'codex?q=spawn_agent'
 ```
+
+Use `meta=1` to include provider thread metadata in each query result. Combine it with `--head` when you only want frontmatter output.
 
 Query role-scoped threads:
 
@@ -147,6 +150,7 @@ xurl [OPTIONS] <URI>
 
 - `q=<keyword>`: filters discovery results by keyword. Use when you want to find conversations by topic.
 - `limit=<n>`: limits discovery result count (default `10`). Use when you need a shorter or longer result list.
+- `meta=1`: includes provider thread metadata in each query result item. Use with discovery/query URIs when you want fields like `cwd` or nested git metadata in the frontmatter.
 - `<key>=<value>`: in write mode (`-d`), `xurl` forwards as `--<key> <value>` to the provider CLI.
 - `<flag>`: in write mode (`-d`), `xurl` forwards as `--<flag>` to the provider CLI.
 
@@ -154,6 +158,7 @@ Examples:
 
 ```text
 agents://codex?q=spawn_agent&limit=10
+agents://codex?limit=5&meta=1
 agents://codex/threads/<conversation_id>
 agents://codex/reviewer
 agents://codex?cd=%2FUsers%2Falice%2Frepo&add-dir=%2FUsers%2Falice%2Fshared

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -105,7 +105,10 @@ Keyword query with optional limit (default `10`):
 ```bash
 xurl 'agents://codex?q=spawn_agent'
 xurl 'agents://claude?q=agent&limit=5'
+xurl 'agents://codex?limit=5&meta=1'
 ```
+
+Use `meta=1` to include provider thread metadata in each query result. Combine it with `--head` when you only want frontmatter output.
 
 Role-scoped query (session-first, role-fallback):
 
@@ -232,6 +235,7 @@ Query parameters:
 
 - `q=<keyword>`: filter discovery results by keyword. Use when searching conversations by topic.
 - `limit=<n>`: cap discovery results (default `10`). Use when you want fewer or more results.
+- `meta=1`: include provider thread metadata in each query result item. Use with discovery/query URIs when you want fields like `cwd` or nested git metadata in frontmatter.
 - `<key>=<value>`: in write mode (`-d`), forwarded as `--<key> <value>` to the provider CLI.
 - `<flag>`: in write mode (`-d`), forwarded as `--<flag>` to the provider CLI.
 

--- a/xurl-cli/tests/cli.rs
+++ b/xurl-cli/tests/cli.rs
@@ -47,6 +47,25 @@ fn setup_codex_tree() -> tempfile::TempDir {
     temp
 }
 
+fn setup_codex_tree_with_metadata() -> tempfile::TempDir {
+    let temp = tempdir().expect("tempdir");
+    let thread_path = temp.path().join(format!(
+        "sessions/2026/02/23/rollout-2026-02-23T04-48-50-{SESSION_ID}.jsonl"
+    ));
+    fs::create_dir_all(thread_path.parent().expect("parent")).expect("mkdir");
+    fs::write(
+        &thread_path,
+        concat!(
+            "{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/tmp/project\",\"git\":{\"branch\":\"main\"}}}\n",
+            "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"hello\"}]}}\n",
+            "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"world\"}]}}\n"
+        ),
+    )
+    .expect("write");
+
+    temp
+}
+
 fn setup_codex_tree_with_sqlite_missing_threads() -> tempfile::TempDir {
     let temp = setup_codex_tree();
     fs::write(temp.path().join("state.sqlite"), "").expect("write sqlite");
@@ -794,7 +813,9 @@ fn codex_collection_query_outputs_markdown() {
         .stdout(predicate::str::contains(format!(
             "agents://codex/{SESSION_ID}"
         )))
-        .stdout(predicate::str::contains("- Match:"));
+        .stdout(predicate::str::contains("- Match:"))
+        .stdout(predicate::str::contains("thread_metadata:").not())
+        .stdout(predicate::str::contains("- Metadata: `disabled`"));
 }
 
 #[test]
@@ -812,6 +833,40 @@ fn shorthand_collection_query_outputs_markdown() {
             "agents://codex/{SESSION_ID}"
         )))
         .stdout(predicate::str::contains("- Match:"));
+}
+
+#[test]
+fn codex_collection_query_with_meta_outputs_thread_metadata() {
+    let temp = setup_codex_tree_with_metadata();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("CODEX_HOME", temp.path())
+        .arg("agents://codex?limit=1&meta=1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("- Metadata: `enabled`"))
+        .stdout(predicate::str::contains("thread_metadata:"))
+        .stdout(predicate::str::contains("type = session_meta"))
+        .stdout(predicate::str::contains("payload.cwd = /tmp/project"))
+        .stdout(predicate::str::contains("payload.git.branch = main"))
+        .stdout(predicate::str::contains("ignored query parameter: meta").not());
+}
+
+#[test]
+fn codex_collection_query_head_with_meta_outputs_frontmatter_only() {
+    let temp = setup_codex_tree_with_metadata();
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("CODEX_HOME", temp.path())
+        .arg("--head")
+        .arg("agents://codex?limit=1&meta=1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("meta: true"))
+        .stdout(predicate::str::contains("thread_metadata:"))
+        .stdout(predicate::str::contains("payload.cwd = /tmp/project"))
+        .stdout(predicate::str::contains("# Threads").not())
+        .stdout(predicate::str::contains("ignored query parameter: meta").not());
 }
 
 #[test]

--- a/xurl-core/src/model.rs
+++ b/xurl-core/src/model.rs
@@ -187,6 +187,7 @@ pub struct ThreadQuery {
     pub role: Option<String>,
     pub q: Option<String>,
     pub limit: usize,
+    pub include_metadata: bool,
     pub ignored_params: Vec<String>,
 }
 
@@ -197,6 +198,8 @@ pub struct ThreadQueryItem {
     pub thread_source: String,
     pub updated_at: Option<String>,
     pub matched_preview: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_metadata: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/xurl-core/src/service.rs
+++ b/xurl-core/src/service.rs
@@ -275,6 +275,19 @@ pub fn query_threads(query: &ThreadQuery, roots: &ProviderRoots) -> Result<Threa
             thread_source: candidate.thread_source.clone(),
             updated_at: candidate.updated_at.clone(),
             matched_preview,
+            thread_metadata: if query.include_metadata {
+                match &candidate.search_target {
+                    QuerySearchTarget::File(path) => {
+                        let (thread_metadata, metadata_warnings) =
+                            collect_thread_metadata(query.provider, path);
+                        warnings.extend(metadata_warnings);
+                        Some(thread_metadata)
+                    }
+                    QuerySearchTarget::Text(_) => None,
+                }
+            } else {
+                None
+            },
         });
     }
 
@@ -292,6 +305,9 @@ pub fn render_thread_query_head_markdown(result: &ThreadQueryResult) -> String {
     push_yaml_string(&mut output, "provider", &result.query.provider.to_string());
     push_yaml_string(&mut output, "mode", "thread_query");
     push_yaml_string(&mut output, "limit", &result.query.limit.to_string());
+    if result.query.include_metadata {
+        push_yaml_bool_with_indent(&mut output, 0, "meta", true);
+    }
     if let Some(role) = &result.query.role {
         push_yaml_string(&mut output, "role", role);
     }
@@ -314,6 +330,9 @@ pub fn render_thread_query_head_markdown(result: &ThreadQueryResult) -> String {
             if let Some(matched_preview) = &item.matched_preview {
                 push_yaml_string_with_indent(&mut output, 2, "matched_preview", matched_preview);
             }
+            if let Some(thread_metadata) = &item.thread_metadata {
+                render_thread_metadata_with_indent(&mut output, 2, thread_metadata);
+            }
         }
     }
 
@@ -333,6 +352,14 @@ pub fn render_thread_query_markdown(result: &ThreadQueryResult) -> String {
         output.push_str("- Role: `_none_`\n");
     }
     output.push_str(&format!("- Limit: `{}`\n", result.query.limit));
+    output.push_str(&format!(
+        "- Metadata: `{}`\n",
+        if result.query.include_metadata {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    ));
     if let Some(q) = &result.query.q {
         output.push_str(&format!("- Query: `{}`\n", q));
     } else {
@@ -354,6 +381,14 @@ pub fn render_thread_query_markdown(result: &ThreadQueryResult) -> String {
         }
         if let Some(matched_preview) = &item.matched_preview {
             output.push_str(&format!("- Match: `{}`\n", matched_preview));
+        }
+        if let Some(thread_metadata) = &item.thread_metadata
+            && !thread_metadata.is_empty()
+        {
+            output.push_str("- Thread Metadata:\n");
+            for entry in thread_metadata {
+                output.push_str(&format!("  - `{entry}`\n"));
+            }
         }
         output.push('\n');
     }
@@ -675,10 +710,19 @@ fn render_thread_metadata(output: &mut String, metadata: &[String]) {
     if metadata.is_empty() {
         return;
     }
+    render_thread_metadata_with_indent(output, 0, metadata);
+}
 
-    output.push_str("thread_metadata:\n");
+fn render_thread_metadata_with_indent(output: &mut String, indent: usize, metadata: &[String]) {
+    let prefix = " ".repeat(indent);
+    output.push_str(&format!("{prefix}thread_metadata:\n"));
+    if metadata.is_empty() {
+        output.push_str(&format!("{prefix}  []\n"));
+        return;
+    }
+
     for value in metadata {
-        output.push_str(&format!("  - '{}'\n", yaml_single_quoted(value)));
+        output.push_str(&format!("{prefix}  - '{}'\n", yaml_single_quoted(value)));
     }
 }
 
@@ -4708,9 +4752,10 @@ mod tests {
 
     use tempfile::tempdir;
 
+    use crate::model::{ProviderKind, ThreadQuery, ThreadQueryItem, ThreadQueryResult};
     use crate::service::{
         collect_claude_thread_metadata, collect_codex_thread_metadata, collect_pi_thread_metadata,
-        extract_last_timestamp, read_thread_raw,
+        extract_last_timestamp, read_thread_raw, render_thread_query_head_markdown,
     };
 
     #[test]
@@ -4805,5 +4850,37 @@ mod tests {
                 .any(|item| item == "type = thinking_level_change")
         );
         assert!(metadata.iter().any(|item| item == "thinkingLevel = medium"));
+    }
+
+    #[test]
+    fn render_thread_query_head_marks_metadata_enabled_and_renders_entries() {
+        let result = ThreadQueryResult {
+            query: ThreadQuery {
+                uri: "agents://codex?limit=1&meta=1".to_string(),
+                provider: ProviderKind::Codex,
+                role: None,
+                q: None,
+                limit: 1,
+                include_metadata: true,
+                ignored_params: Vec::new(),
+            },
+            items: vec![ThreadQueryItem {
+                thread_id: "019c871c-b1f9-7f60-9c4f-87ed09f13592".to_string(),
+                uri: "agents://codex/019c871c-b1f9-7f60-9c4f-87ed09f13592".to_string(),
+                thread_source: "/tmp/mock.jsonl".to_string(),
+                updated_at: Some("123".to_string()),
+                matched_preview: None,
+                thread_metadata: Some(vec![
+                    "type = session_meta".to_string(),
+                    "payload.cwd = /tmp/project".to_string(),
+                ]),
+            }],
+            warnings: Vec::new(),
+        };
+
+        let output = render_thread_query_head_markdown(&result);
+        assert!(output.contains("meta: true"));
+        assert!(output.contains("thread_metadata:"));
+        assert!(output.contains("payload.cwd = /tmp/project"));
     }
 }

--- a/xurl-core/src/uri.rs
+++ b/xurl-core/src/uri.rs
@@ -368,9 +368,10 @@ pub fn parse_role_uri(input: &str) -> Result<Option<RoleUri>> {
 fn parse_thread_query_pairs(
     input: &str,
     query_raw: &str,
-) -> Result<(Option<String>, usize, Vec<String>)> {
+) -> Result<(Option<String>, usize, bool, Vec<String>)> {
     let mut q = None::<String>;
     let mut limit = None::<usize>;
+    let mut include_metadata = false;
     let mut ignored_params = Vec::<String>::new();
 
     for pair in query_raw.split('&').filter(|pair| !pair.is_empty()) {
@@ -390,6 +391,9 @@ fn parse_thread_query_pairs(
                     XurlError::InvalidUri(format!("{input} (invalid limit={value})"))
                 })?);
             }
+            "meta" => {
+                include_metadata = parse_thread_query_bool(input, "meta", &value)?;
+            }
             _ => {
                 if !ignored_params.iter().any(|existing| existing == &key) {
                     ignored_params.push(key);
@@ -398,7 +402,17 @@ fn parse_thread_query_pairs(
         }
     }
 
-    Ok((q, limit.unwrap_or(10), ignored_params))
+    Ok((q, limit.unwrap_or(10), include_metadata, ignored_params))
+}
+
+fn parse_thread_query_bool(input: &str, key: &str, value: &str) -> Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "1" | "true" => Ok(true),
+        "0" | "false" => Ok(false),
+        other => Err(XurlError::InvalidUri(format!(
+            "{input} (invalid {key}={other})"
+        ))),
+    }
 }
 
 pub fn parse_collection_query_uri(input: &str) -> Result<Option<ThreadQuery>> {
@@ -416,7 +430,7 @@ pub fn parse_collection_query_uri(input: &str) -> Result<Option<ThreadQuery>> {
     }
 
     let provider = parse_provider(provider_part)?;
-    let (q, limit, ignored_params) = parse_thread_query_pairs(input, query_raw)?;
+    let (q, limit, include_metadata, ignored_params) = parse_thread_query_pairs(input, query_raw)?;
 
     Ok(Some(ThreadQuery {
         uri: input.to_string(),
@@ -424,6 +438,7 @@ pub fn parse_collection_query_uri(input: &str) -> Result<Option<ThreadQuery>> {
         role: None,
         q,
         limit,
+        include_metadata,
         ignored_params,
     }))
 }
@@ -441,7 +456,7 @@ pub fn parse_role_query_uri(input: &str) -> Result<Option<ThreadQuery>> {
         input
     };
     let (_, query_raw) = target.split_once('?').map_or((target, ""), |parts| parts);
-    let (q, limit, ignored_params) = parse_thread_query_pairs(input, query_raw)?;
+    let (q, limit, include_metadata, ignored_params) = parse_thread_query_pairs(input, query_raw)?;
 
     Ok(Some(ThreadQuery {
         uri: input.to_string(),
@@ -449,6 +464,7 @@ pub fn parse_role_query_uri(input: &str) -> Result<Option<ThreadQuery>> {
         role: Some(role_uri.role),
         q,
         limit,
+        include_metadata,
         ignored_params,
     }))
 }
@@ -837,6 +853,7 @@ mod tests {
         assert_eq!(query.role, None);
         assert_eq!(query.q, None);
         assert_eq!(query.limit, 10);
+        assert!(!query.include_metadata);
         assert!(query.ignored_params.is_empty());
     }
 
@@ -849,6 +866,7 @@ mod tests {
         assert_eq!(query.role, None);
         assert_eq!(query.q, Some("spawn agent".to_string()));
         assert_eq!(query.limit, 7);
+        assert!(!query.include_metadata);
     }
 
     #[test]
@@ -860,6 +878,17 @@ mod tests {
         assert_eq!(query.role, None);
         assert_eq!(query.q, Some("spawn agent".to_string()));
         assert_eq!(query.limit, 7);
+        assert!(!query.include_metadata);
+    }
+
+    #[test]
+    fn parse_collection_query_uri_with_meta_flag() {
+        let query = parse_collection_query_uri("agents://codex?meta=1&limit=3")
+            .expect("collection query parse must work");
+        let query = query.expect("query should be present");
+        assert_eq!(query.provider, ProviderKind::Codex);
+        assert_eq!(query.limit, 3);
+        assert!(query.include_metadata);
     }
 
     #[test]
@@ -876,6 +905,13 @@ mod tests {
     fn parse_collection_query_uri_rejects_invalid_limit() {
         let err = parse_collection_query_uri("agents://gemini?limit=abc")
             .expect_err("invalid limit should fail");
+        assert!(format!("{err}").contains("invalid uri"));
+    }
+
+    #[test]
+    fn parse_collection_query_uri_rejects_invalid_meta_flag() {
+        let err = parse_collection_query_uri("agents://gemini?meta=maybe")
+            .expect_err("invalid meta should fail");
         assert!(format!("{err}").contains("invalid uri"));
     }
 
@@ -926,6 +962,17 @@ mod tests {
         assert_eq!(query.role, Some("reviewer".to_string()));
         assert_eq!(query.q, Some("spawn agent".to_string()));
         assert_eq!(query.limit, 3);
+        assert!(!query.include_metadata);
+    }
+
+    #[test]
+    fn parse_role_query_uri_with_meta_flag() {
+        let query = parse_role_query_uri("agents://codex/reviewer?meta=1")
+            .expect("role query parse must succeed");
+        let query = query.expect("query must exist");
+        assert_eq!(query.provider, ProviderKind::Codex);
+        assert_eq!(query.role, Some("reviewer".to_string()));
+        assert!(query.include_metadata);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add `meta=1` for collection and role queries so query results can include per-thread metadata when requested.

## Why

Thread queries like `xurl 'agents://codex?limit=10'` currently return discovery fields (`thread_id`, `thread_source`, `updated_at`, `matched_preview`), but not provider metadata such as working directory or git branch.

That makes discovery possible, but it still forces a second step to inspect each candidate thread one by one.

`--head` is not enough here because it is only an output-mode switch. For collection queries, `--head` removes the markdown body, but it does not expand each result item with metadata.

`meta=1` fills that gap by letting callers request metadata directly in the query result.

## Relation to #33

This PR is intended to build on top of #33, not compete with it.

PR #33 narrows the metadata shown in single-thread `--head` output so the metadata surface is smaller and less noisy. After that behavior is settled, this PR applies the same metadata policy to collection and role queries by adding an explicit `meta=1` opt-in.

So the intended sequence is:

1. merge #33 to define the reduced metadata behavior
2. rebase/update this PR on top of that behavior
3. keep `meta=1` using the same reduced metadata set for query results

## Changes

- parse `meta=1` on collection and role query URIs
- carry the flag through `ThreadQuery`
- attach `thread_metadata` to query result items when available
- render metadata in both default query output and `--head` query output
- keep default behavior unchanged when `meta` is not requested
- update `README.md` and `skills/xurl/SKILL.md`

## Tests

Added URI parsing, core rendering, and CLI coverage for default behavior, `meta=1`, and `--head` + `meta=1`. Full `xurl-cli` integration tests pass locally.
