### PR TITLE
docs: preserve existing statusline layout

### DIFF
--- a/plugins/xurl-statusline/README.md
+++ b/plugins/xurl-statusline/README.md
@@ -16,10 +16,10 @@ Ask Claude to use the `xurl-statusline-installer` agent to configure your status
 Copy and send:
 
 ```text
-Use the xurl-statusline-installer agent to configure Claude Code status line for the xurl-statusline plugin.
+Use the xurl-statusline-installer agent to add the xurl agents URI to my Claude Code status line. Keep my existing status line layout and settings intact, and avoid replacing my current status line unless that is the only safe option.
 ```
 
-The agent updates `~/.claude/settings.json` for you. Run it again after plugin updates so the path stays current.
+The agent updates `~/.claude/settings.json` for you and should preserve your existing status line layout whenever possible. Run it again after plugin updates so the path stays current.
 
 The script prints:
 

--- a/plugins/xurl-statusline/agents/xurl-statusline-installer.md
+++ b/plugins/xurl-statusline/agents/xurl-statusline-installer.md
@@ -8,11 +8,14 @@ You install and refresh the xurl status line configuration for Claude Code.
 When invoked:
 
 1. Read `~/.claude/settings.json` if it exists.
-2. Update or create `statusLine.command` with:
+2. Inspect the existing `statusLine` configuration before making changes.
+3. Preserve the user's current status line layout and unrelated settings.
+4. Add the xurl `agents://...` URI organically instead of replacing the user's existing status line setup.
+5. If no `statusLine.command` exists yet, set it to:
    `node ${CLAUDE_PLUGIN_ROOT}/scripts/agents_uri_statusline.js`
-3. Preserve unrelated settings.
-4. If `statusLine` exists, keep existing fields unless they conflict with the command-based status line setup.
-5. Tell the user which file you changed and the final command value.
+6. If `statusLine.command` already exists and is not the xurl command, do not overwrite it blindly. Integrate the xurl renderer in a way that keeps the current layout intact, using the smallest safe change.
+7. If `statusLine.command` already points to xurl, refresh the path only if needed.
+8. Tell the user which file you changed, how you preserved the existing layout, and the final command value.
 
 Rules:
 
@@ -20,4 +23,6 @@ Rules:
 - If the settings file is missing, create a minimal valid JSON object.
 - Keep the file formatted as readable JSON.
 - Do not modify any other Claude files.
+- Prioritize preserving existing `statusLine` fields such as `padding` or other layout-related keys.
+- If an existing custom status line cannot be merged safely without understanding the user's intent, stop and explain the conflict instead of overwriting it.
 - Mention that the user should run this agent again after plugin updates so the path stays current.


### PR DESCRIPTION
This updates the xurl statusline installer guidance so it integrates the `agents://` URI into the user's existing Claude Code status line instead of overwriting custom layout by default.

The installer agent and plugin README now explicitly prioritize preserving existing `statusLine` settings and only replacing the current setup when that is the only safe option.
