### PR TITLE
Add optional local search index cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ xurl agents://codex/reviewer
 
 Query results include reduced thread metadata when available, so you can inspect fields like `payload.git.branch` without opening each thread individually.
 
+Repeated queries reuse a local on-demand search index. `xurl` refreshes it during normal reads, writes, and queries, so no background process is required. Set `XURL_DISABLE_SEARCH_INDEX=1` to force direct scanning.
+
 ### Discover
 
 ```bash

--- a/docs/search-index-benchmark-design.md
+++ b/docs/search-index-benchmark-design.md
@@ -1,0 +1,148 @@
+# Search Index Benchmark Design
+
+## Status
+
+Implemented
+
+## Purpose
+
+This document defines a repository benchmark for the optional local search index so `xurl` can track performance regressions without depending on ad-hoc scripts.
+
+The benchmark lives under `xurl-core/benches/` and runs via `cargo bench`.
+
+## Entry
+
+Run the benchmark with:
+
+```bash
+cargo bench -p xurl-core --bench search_index
+```
+
+Optional tuning arguments are passed after `--`:
+
+```bash
+cargo bench -p xurl-core --bench search_index -- --threads 2500 --samples 5
+```
+
+## Scope
+
+The current benchmark covers the `codex` provider only.
+
+Reasons:
+
+- it is the simplest file-backed provider to synthesize deterministically
+- it exercises the same collection-query and index-maintenance path used by production code
+- it avoids provider-specific database setup that would make regression data noisier
+
+If other providers need dedicated regression coverage later, they should add separate benchmark modes instead of stretching this one into a generic cross-provider harness.
+
+This benchmark is intended to track three different cost centers separately:
+
+- foreground query latency
+- background refresh latency
+- FTS rebuild latency after discovery and materialization are already cached
+
+## Workload Model
+
+The benchmark generates a synthetic `CODEX_HOME` corpus inside a temporary directory.
+
+Default corpus:
+
+- `2500` transcripts
+- one target transcript containing the cold and warm query keyword
+- one separate transcript rewritten later for incremental refresh measurement
+
+The benchmark uses fixed keywords:
+
+- base query: `bench-hit`
+- incremental query: `bench-incremental-hit`
+
+This keeps comparisons stable across runs.
+
+## Measured Scenarios
+
+Each scenario uses an isolated temporary workspace so results do not bleed into each other.
+
+### Cold Query
+
+- index enabled
+- index initially empty
+- measures foreground query latency with index-open overhead but without prior maintenance
+
+### No-Index Query
+
+- `XURL_DISABLE_SEARCH_INDEX=1`
+- measures direct-scan latency without any index behavior
+
+### Full Build
+
+- runs `maintain_search_index_for_uri("agents://codex", ...)`
+- measures one full background build for the benchmark scope
+
+### FTS Rebuild
+
+- builds the full index first
+- deletes only `thread_fts` rows while keeping other sidecar cache state
+- runs `maintain_search_index_for_uri("agents://codex", ...)` again
+- measures how quickly the worker can rebuild search rows from cached materialization data
+
+### Warm Query
+
+- builds the full index first
+- then runs the foreground query
+- measures steady-state query latency with a populated index
+
+### Incremental Refresh
+
+- builds the full index first
+- rewrites one transcript
+- runs `maintain_search_index_for_uri("agents://codex", ...)` again
+- measures the incremental maintenance cost
+
+### Incremental Query
+
+- runs immediately after incremental refresh
+- measures query latency for the newly indexed keyword
+
+## Isolation Rules
+
+The benchmark must avoid contaminating its own timings.
+
+Rules:
+
+- every sample uses a fresh corpus and fresh index path
+- the benchmark exercises `xurl-core` APIs directly
+- search-index env overrides are scoped and restored inside the bench process
+
+This keeps the benchmark reproducible while avoiding unrelated CLI process overhead.
+
+It also means:
+
+- `full_build` includes provider discovery, transcript materialization, and FTS insertion
+- `fts_rebuild` isolates the FTS insertion path much more closely
+- `incremental_refresh` reflects the common case where only a very small subset of threads has changed
+
+## Output Contract
+
+The benchmark prints JSON to stdout.
+
+The output must include:
+
+- benchmark metadata
+- corpus size and sample count
+- per-sample arrays for each scenario
+- summary averages
+- derived comparison fields such as cold overhead and warm speedup
+
+The JSON shape is intended to be stable enough for simple diffing in scripts or CI logs.
+
+## Tuning
+
+The benchmark accepts:
+
+- `--threads`
+- `--samples`
+
+These exist so tests and faster local runs can shrink the corpus without changing the benchmark logic.
+
+The defaults should remain biased toward signal quality rather than minimal runtime.

--- a/docs/search-index-maintenance-design.md
+++ b/docs/search-index-maintenance-design.md
@@ -1,0 +1,342 @@
+# Search Index Maintenance Design
+
+## Status
+
+Implemented
+
+## Purpose
+
+This document defines how `xurl` maintains its optional local search index without introducing a user-facing command, a daemon, or a long-running background service.
+
+The search index is a cache:
+
+- it accelerates query candidate pruning
+- it may cache provider discovery state such as manifests or watermarks
+- it is never the source of truth
+- it may be deleted and rebuilt at any time
+- failures in the index layer must not affect normal `xurl` correctness
+
+## Current Architecture
+
+The implemented cache stack has four layers:
+
+1. provider source of truth
+   - provider transcript files or provider-owned sqlite databases
+2. provider discovery cache
+   - `provider_manifest`
+   - `provider_watermarks`
+3. thread materialization cache
+   - `thread_materialization`
+   - stores `search_text`, `scope_path`, and the source fingerprint that produced them
+4. search index
+   - `thread_fts`
+   - used only for query candidate pruning
+
+The key separation is:
+
+- discovery cache avoids rescanning provider metadata
+- materialization cache avoids rereading unchanged transcripts
+- `thread_fts` avoids rescanning full text during query
+
+All four layers live in one sidecar sqlite file so version mismatch can be handled by deleting one cache family and rebuilding.
+
+## Goals
+
+- Keep the index fully optional
+- Avoid user-visible index management commands
+- Avoid a daemon, watcher, or persistent worker process
+- Keep query/read/write correctness independent from the index
+- Move non-essential index maintenance off the foreground command path
+
+## Non-Goals
+
+- No public `index` subcommand
+- No user-visible background service lifecycle
+- No requirement that the index is globally up to date before every query
+- No index-only query execution path that bypasses transcript verification
+
+## Internal Worker Entry
+
+`xurl` may launch itself in an internal maintenance mode:
+
+```bash
+xurl -X index <uri>
+```
+
+This mode is internal:
+
+- `-X` is hidden from normal help output
+- it is not documented in `README.md`
+- it is not documented in `skills/xurl/SKILL.md`
+- normal user workflows must not depend on calling it directly
+
+The internal worker exists only so the foreground process can offload cache maintenance into a short-lived child process.
+
+## Why Hidden Argv Instead of Env or Public Command
+
+Hidden argv is preferred because:
+
+- it keeps behavior explicit inside the process model
+- it avoids environment-variable protocol drift
+- it avoids exposing a user-facing command for an implementation detail
+- it remains easy to debug in logs or process listings
+
+This is still an internal contract, not a public interface.
+
+## Foreground vs Background Responsibilities
+
+### Foreground Command
+
+Normal `xurl` invocations should:
+
+- read from the existing search index when available
+- fall back to direct transcript scanning when the index misses, is stale, or is unavailable
+- keep the current thread visible after successful read/write hot paths
+- optionally enqueue or trigger background maintenance after the main result is already ready
+
+Foreground commands should not spend meaningful time doing broad index backfill.
+
+### Background Worker
+
+The internal worker should:
+
+- resolve the requested URI scope
+- collect candidates for that scope
+- refresh stale or missing index entries
+- optionally prune entries that no longer exist within that scope
+- finish the requested scope in one run when possible
+
+The worker should be best-effort only. Failures must not affect the parent command.
+
+The implemented worker path currently focuses on refresh rather than explicit scoped prune. Missing or invalid threads naturally disappear when provider discovery data is rebuilt.
+
+## Trigger Model
+
+After a normal command succeeds, `xurl` may best-effort spawn:
+
+```bash
+xurl -X index <narrowest-relevant-uri>
+```
+
+Examples:
+
+- provider query:
+  - parent command: `xurl 'agents://codex?q=refactor'`
+  - spawned worker: `xurl -X index agents://codex?q=refactor`
+- path query:
+  - parent command: `xurl 'agents:///repo?providers=codex,claude'`
+  - spawned worker: `xurl -X index 'agents:///repo?providers=codex,claude'`
+- thread read:
+  - parent command: `xurl agents://codex/<session_id>`
+  - spawned worker: `xurl -X index agents://codex/<session_id>`
+
+The parent process must not wait for the child worker.
+
+## Scope Rules
+
+The worker scope is derived from the URI:
+
+- `agents://<provider>`
+  - refresh candidates for that provider
+- `agents:///abs/path?...`
+  - refresh candidates only under that path scope and provider filter
+- `agents://<provider>/<session_id>`
+  - refresh only that thread
+
+This keeps maintenance narrow and aligned with actual usage.
+
+## Correctness Contract
+
+The search index must not be required for correctness.
+
+That means:
+
+- query results must still be found when the index is missing
+- stale index entries must not suppress correct fallback matches
+- index corruption must not cause normal read/query/write failure
+
+If the index layer fails, `xurl` must degrade to direct scanning.
+
+## Failure Handling
+
+The index is cache state, so failure handling should be aggressive and simple.
+
+Recommended policy:
+
+- open failure: ignore the index for this command
+- sqlite version mismatch: delete the local sqlite files and recreate the cache
+- corruption: delete and recreate the index
+- worker failure: ignore and continue
+- worker spawn failure: ignore and continue
+
+None of these should change the main command exit code.
+
+## Concurrency Control
+
+Multiple foreground commands may try to launch `-X index`.
+
+The worker should use a lightweight lease so only one worker performs maintenance at a time.
+
+Recommended options:
+
+- sqlite lease row with expiry
+- lock file in the index state directory
+
+If the lease cannot be acquired, the worker should exit immediately.
+
+Because the index is only a cache, missed maintenance is acceptable.
+
+## Sidecar Cache Contents
+
+The sidecar sqlite is not limited to FTS rows.
+
+It may store:
+
+- transcript search documents used by `thread_fts`
+- transcript materialization rows used to rebuild `thread_fts` without rereading source files
+- provider discovery manifests keyed by provider
+- provider-level watermarks used to decide whether discovery data can be reused
+- lightweight worker lease metadata
+
+This keeps all cache state in one place and allows `xurl` to delete and rebuild the whole sqlite file when the cache schema changes.
+
+In the current implementation the cache version is controlled by one global sqlite `user_version`, not per-table migration state.
+
+## Sqlite Versioning
+
+The cache sqlite should use a single global version via `PRAGMA user_version`.
+
+If the on-disk version does not match the runtime version, `xurl` should:
+
+1. delete the sqlite database together with its `-wal` and `-shm` files
+2. recreate the cache from scratch
+
+Because the index is optional and rebuild cost is acceptable, whole-file replacement is preferred over in-place migration.
+
+## Provider Discovery Cache
+
+Providers may benefit from caching candidate discovery separately from transcript search text.
+
+Two cache forms are supported:
+
+- watermark:
+  - a cheap provider-level summary that tells whether the provider's discovery source has changed
+- manifest:
+  - the cached list of discovered threads plus lightweight metadata such as URI, source path, and optional scope path
+
+When a provider watermark matches, the worker may reuse the manifest from the sidecar sqlite instead of rescanning the provider's external state.
+
+The manifest is still cache data:
+
+- transcript freshness must still be validated from current source metadata before trusting indexed search text
+- missing or changed transcripts must not be hidden by manifest reuse
+
+### Initial Provider Target
+
+`codex` is the first provider to use this pattern.
+
+Its external `state.sqlite` files provide:
+
+- a natural provider discovery source
+- a cheap watermark based on sqlite file metadata
+- enough thread identity data to rebuild a provider manifest inside the sidecar cache
+
+For `codex`, path-scoped maintenance also benefits from caching `scope_path` inside both the provider manifest and thread materialization rows, so path queries do not need to reread all transcripts just to recover scope metadata.
+
+## Materialization Cache
+
+The sidecar sqlite may also store a materialization cache per thread:
+
+- `search_text`
+- cached `scope_path`
+- the source fingerprint that produced them
+
+This cache exists so maintenance can distinguish between:
+
+- source work:
+  - reread and reparse the original transcript
+- index work:
+  - repopulate `thread_fts` from already materialized text
+
+When the source fingerprint still matches, the worker should prefer rebuilding `thread_fts` from cached materialization data instead of rereading the transcript.
+
+The current implementation also distinguishes between:
+
+- materialized insert
+  - FTS row missing, materialization row already present
+- materialized replace
+  - both rows present but FTS row stale or missing a fresh fingerprint
+- built insert
+  - transcript must be read and the FTS row does not exist yet
+- built replace
+  - transcript must be read and an old FTS row must be replaced
+
+This split exists to avoid unnecessary `DELETE` work for rows that do not yet exist in `thread_fts`, which materially reduces full-build and rebuild cost.
+
+## Index Update Strategy
+
+### Query Path
+
+Normal query should:
+
+1. use the search index as the first lookup path when the query shape and provider support a safe fast path
+2. verify indexed hits against the current transcript source before returning them
+3. fall back to candidate collection and direct scanning when the fast path cannot satisfy the request
+4. return results
+
+It should not do broad in-process index refresh beyond trivial current-thread work.
+
+This is implemented today:
+
+- provider and path queries use safe index-first fast paths for supported query shapes
+- indexed hits are always revalidated against current transcript source before being returned
+- unsupported or insufficient fast-path results fall back to the original candidate scan path
+
+### Read Path
+
+A successful thread read may refresh that exact thread synchronously because:
+
+- the raw transcript is already loaded
+- the scope is narrow
+- this preserves strong local visibility for recently opened threads
+
+This is implemented today and writes both `thread_fts` and `thread_materialization` for the exact thread when possible.
+
+### Write Path
+
+A successful write may refresh the resulting thread synchronously when resolvable.
+
+If the provider has not materialized the final transcript yet, the worker can catch it later.
+
+This is implemented as a best-effort refresh and does not change write correctness if the cache path fails.
+
+## Worker Runtime
+
+The worker should prefer completing the requested scope in one run.
+
+The index is already outside the foreground command path, so partial maintenance should not be the default behavior.
+
+If future providers require chunked maintenance because one scope becomes too large, that should be added as a provider-specific continuation mechanism rather than a blanket global limit.
+
+## Current Performance Interpretation
+
+The current architecture has established these performance boundaries:
+
+- query latency is mainly improved by `thread_fts` fast paths
+- provider maintenance latency is reduced first by provider manifest reuse
+- transcript reread cost is reduced by thread materialization reuse
+- remaining rebuild cost is dominated by actual `thread_fts` insertion work
+
+This means future maintenance optimization should focus on FTS write strategy before adding more caching layers.
+
+## Relationship to User Docs
+
+User-facing docs should only describe the user-visible behavior:
+
+- repeated queries may become faster over time
+- no daemon is required
+- direct scanning remains the fallback path
+
+User-facing docs should not mention `-X index`.
+
+Internal regression benchmarking for this cache layer is defined separately in `docs/search-index-benchmark-design.md`.

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -134,6 +134,8 @@ xurl codex/reviewer
 
 Query results include reduced thread metadata (e.g. `payload.git.branch`, `cwd`) for quick inspection.
 
+Repeated queries reuse a local on-demand search index. `xurl` refreshes it during normal reads, writes, and queries, so no background process is required. Set `XURL_DISABLE_SEARCH_INDEX=1` to force direct scanning when debugging search behavior.
+
 ### 2. Read — Display a Conversation
 
 ```bash

--- a/xurl-cli/src/main.rs
+++ b/xurl-cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::process::ExitCode;
+use std::process::{Command, ExitCode, Stdio};
 use std::{fs, io};
 
 use std::io::{Read, Write};
@@ -11,7 +11,7 @@ use xurl_core::uri::{
 };
 use xurl_core::{
     AgentsUri, ProviderKind, ProviderRoots, WriteEventSink, WriteOptions, WriteRequest,
-    WriteResult, XurlError, query_threads, query_threads_by_path,
+    WriteResult, XurlError, maintain_search_index_for_uri, query_threads, query_threads_by_path,
     render_path_thread_query_head_markdown, render_path_thread_query_markdown,
     render_subagent_view_markdown, render_thread_head_markdown, render_thread_markdown,
     render_thread_query_head_markdown, render_thread_query_markdown, resolve_subagent_view,
@@ -21,6 +21,10 @@ use xurl_core::{
 #[derive(Debug, Parser)]
 #[command(name = "xurl", version, about = "Resolve and read code-agent threads")]
 struct Cli {
+    /// Internal execution mode. Hidden because search-index maintenance is an implementation detail.
+    #[arg(short = 'X', hide = true, value_name = "MODE")]
+    internal_mode: Option<String>,
+
     /// Thread URI like agents://codex/<session_id>, codex/<session_id>, agents://claude/<session_id>, agents://pi/<session_id>/<child_or_entry_id>, or legacy forms like codex://<session_id>
     uri: String,
 
@@ -52,6 +56,7 @@ fn main() -> ExitCode {
 
 fn run(cli: Cli) -> xurl_core::Result<()> {
     let Cli {
+        internal_mode,
         uri,
         head,
         data,
@@ -59,6 +64,10 @@ fn run(cli: Cli) -> xurl_core::Result<()> {
     } = cli;
     let roots = ProviderRoots::from_env_or_home()?;
     let output = output.as_deref();
+
+    if let Some(mode) = internal_mode.as_deref() {
+        return run_internal_mode(mode, &uri, &roots);
+    }
 
     if data.is_empty() {
         if let Some(query) = parse_path_query_uri(&uri)? {
@@ -68,7 +77,9 @@ fn run(cli: Cli) -> xurl_core::Result<()> {
             } else {
                 render_path_thread_query_markdown(&result)
             };
-            return write_output(output, &output_body);
+            write_output(output, &output_body)?;
+            spawn_background_index_worker(&uri);
+            return Ok(());
         }
 
         if let Some(query) = parse_collection_query_uri(&uri)? {
@@ -78,7 +89,9 @@ fn run(cli: Cli) -> xurl_core::Result<()> {
             } else {
                 render_thread_query_markdown(&result)
             };
-            return write_output(output, &output_body);
+            write_output(output, &output_body)?;
+            spawn_background_index_worker(&uri);
+            return Ok(());
         }
 
         if let Some(query) = parse_role_query_uri(&uri)? {
@@ -88,7 +101,9 @@ fn run(cli: Cli) -> xurl_core::Result<()> {
             } else {
                 render_thread_query_markdown(&result)
             };
-            return write_output(output, &output_body);
+            write_output(output, &output_body)?;
+            spawn_background_index_worker(&uri);
+            return Ok(());
         }
 
         let uri = AgentsUri::parse(&uri)?;
@@ -154,6 +169,15 @@ fn run(cli: Cli) -> xurl_core::Result<()> {
     Ok(())
 }
 
+fn run_internal_mode(mode: &str, uri: &str, roots: &ProviderRoots) -> xurl_core::Result<()> {
+    match mode {
+        "index" => maintain_search_index_for_uri(uri, roots),
+        other => Err(XurlError::InvalidMode(format!(
+            "unknown internal mode: {other}"
+        ))),
+    }
+}
+
 fn write_output(path: Option<&Path>, content: &str) -> xurl_core::Result<()> {
     if let Some(path) = path {
         std::fs::write(path, content).map_err(|source| XurlError::Io {
@@ -165,6 +189,22 @@ fn write_output(path: Option<&Path>, content: &str) -> xurl_core::Result<()> {
     }
 
     Ok(())
+}
+
+fn spawn_background_index_worker(uri: &str) {
+    let Ok(current_exe) = std::env::current_exe() else {
+        return;
+    };
+
+    let mut command = Command::new(current_exe);
+    command
+        .arg("-X")
+        .arg("index")
+        .arg(uri)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let _ = command.spawn();
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/xurl-cli/tests/cli.rs
+++ b/xurl-cli/tests/cli.rs
@@ -90,6 +90,22 @@ fn setup_codex_tree_with_scope(scope: &Path) -> tempfile::TempDir {
     temp
 }
 
+fn codex_thread_path(root: &Path) -> PathBuf {
+    root.join(format!(
+        "sessions/2026/02/23/rollout-2026-02-23T04-48-50-{SESSION_ID}.jsonl"
+    ))
+}
+
+fn read_index_search_text(index_path: &Path, provider: &str, thread_id: &str) -> String {
+    let conn = Connection::open(index_path).expect("open index");
+    conn.query_row(
+        "SELECT search_text FROM thread_fts WHERE provider = ?1 AND thread_id = ?2 LIMIT 1",
+        params![provider, thread_id],
+        |row| row.get::<_, String>(0),
+    )
+    .expect("search text row")
+}
+
 fn setup_codex_tree_with_sqlite_missing_threads() -> tempfile::TempDir {
     let temp = setup_codex_tree();
     fs::write(temp.path().join("state.sqlite"), "").expect("write sqlite");
@@ -878,6 +894,88 @@ fn codex_collection_query_outputs_markdown() {
         .stdout(predicate::str::contains("type = session_meta"))
         .stdout(predicate::str::contains("payload.cwd = /tmp/project"))
         .stdout(predicate::str::contains("payload.git.branch = main"));
+}
+
+#[test]
+fn codex_collection_query_creates_search_index_file() {
+    let temp = setup_codex_tree_with_metadata();
+    let index_home = tempdir().expect("tempdir");
+    let index_path = index_home.path().join("search-index.sqlite3");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("CODEX_HOME", temp.path())
+        .env("XURL_SEARCH_INDEX_PATH", &index_path)
+        .arg("-X")
+        .arg("index")
+        .arg("agents://codex")
+        .assert()
+        .success();
+
+    assert!(index_path.exists(), "search index file should be created");
+    assert!(read_index_search_text(&index_path, "codex", SESSION_ID).contains("hello"));
+}
+
+#[test]
+fn codex_collection_query_can_disable_search_index() {
+    let temp = setup_codex_tree_with_metadata();
+    let index_home = tempdir().expect("tempdir");
+    let index_path = index_home.path().join("search-index.sqlite3");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    cmd.env("CODEX_HOME", temp.path())
+        .env("XURL_SEARCH_INDEX_PATH", &index_path)
+        .env("XURL_DISABLE_SEARCH_INDEX", "1")
+        .arg("-X")
+        .arg("index")
+        .arg("agents://codex")
+        .assert()
+        .success();
+
+    assert!(
+        !index_path.exists(),
+        "search index file should not be created when disabled"
+    );
+}
+
+#[test]
+fn codex_collection_query_refreshes_stale_index_after_file_change() {
+    let temp = setup_codex_tree_with_metadata();
+    let index_home = tempdir().expect("tempdir");
+    let index_path = index_home.path().join("search-index.sqlite3");
+
+    let mut warm = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    warm.env("CODEX_HOME", temp.path())
+        .env("XURL_SEARCH_INDEX_PATH", &index_path)
+        .arg("-X")
+        .arg("index")
+        .arg("agents://codex")
+        .assert()
+        .success();
+
+    let thread_path = codex_thread_path(temp.path());
+    fs::write(
+        &thread_path,
+        concat!(
+            "{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/tmp/project\",\"git\":{\"branch\":\"main\"}}}\n",
+            "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"goodbye\"}]}}\n",
+            "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"planet\"}]}}\n"
+        ),
+    )
+    .expect("rewrite");
+
+    let mut rebuild = Command::new(assert_cmd::cargo::cargo_bin!("xurl"));
+    rebuild
+        .env("CODEX_HOME", temp.path())
+        .env("XURL_SEARCH_INDEX_PATH", &index_path)
+        .arg("-X")
+        .arg("index")
+        .arg("agents://codex")
+        .assert()
+        .success();
+
+    let search_text = read_index_search_text(&index_path, "codex", SESSION_ID);
+    assert!(search_text.contains("goodbye"));
+    assert!(!search_text.contains("hello"));
 }
 
 #[test]

--- a/xurl-core/Cargo.toml
+++ b/xurl-core/Cargo.toml
@@ -12,6 +12,10 @@ readme = "../README.md"
 keywords = ["agent", "url", "codex", "claude", "gemini"]
 categories = ["command-line-utilities", "development-tools"]
 
+[[bench]]
+name = "search_index"
+harness = false
+
 [dependencies]
 dirs = "6.0.0"
 grep = "0.4.1"

--- a/xurl-core/benches/search_index.rs
+++ b/xurl-core/benches/search_index.rs
@@ -1,0 +1,465 @@
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+use serde_json::json;
+use tempfile::TempDir;
+use xurl_core::{
+    ProviderKind, ProviderRoots, ThreadQuery, maintain_search_index_for_uri, query_threads,
+};
+
+const TARGET_QUERY_KEYWORD: &str = "bench-hit";
+const INCREMENTAL_QUERY_KEYWORD: &str = "bench-incremental-hit";
+const FILLER_TEXT: &str = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega repeated search filler text";
+
+fn main() {
+    match run() {
+        Ok(()) => {}
+        Err(err) => {
+            eprintln!("error: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run() -> xurl_core::Result<()> {
+    let options = BenchOptions::from_args(env::args().skip(1))?;
+
+    let mut cold_query_ms = Vec::with_capacity(options.samples);
+    let mut no_index_query_ms = Vec::with_capacity(options.samples);
+    let mut full_build_ms = Vec::with_capacity(options.samples);
+    let mut fts_rebuild_ms = Vec::with_capacity(options.samples);
+    let mut warm_query_ms = Vec::with_capacity(options.samples);
+    let mut incremental_refresh_ms = Vec::with_capacity(options.samples);
+    let mut incremental_query_ms = Vec::with_capacity(options.samples);
+
+    for _ in 0..options.samples {
+        let workspace = SearchIndexBenchWorkspace::create(options.threads)?;
+        cold_query_ms.push(duration_ms(measure(|| {
+            workspace.run_query(TARGET_QUERY_KEYWORD, false)
+        })?));
+    }
+
+    for _ in 0..options.samples {
+        let workspace = SearchIndexBenchWorkspace::create(options.threads)?;
+        no_index_query_ms.push(duration_ms(measure(|| {
+            workspace.run_query(TARGET_QUERY_KEYWORD, true)
+        })?));
+    }
+
+    for _ in 0..options.samples {
+        let workspace = SearchIndexBenchWorkspace::create(options.threads)?;
+        full_build_ms.push(duration_ms(measure(|| workspace.maintain_index())?));
+    }
+
+    for _ in 0..options.samples {
+        let workspace = SearchIndexBenchWorkspace::create(options.threads)?;
+        workspace.maintain_index()?;
+        workspace.clear_search_documents()?;
+        fts_rebuild_ms.push(duration_ms(measure(|| workspace.maintain_index())?));
+    }
+
+    for _ in 0..options.samples {
+        let workspace = SearchIndexBenchWorkspace::create(options.threads)?;
+        workspace.maintain_index()?;
+        warm_query_ms.push(duration_ms(measure(|| {
+            workspace.run_query(TARGET_QUERY_KEYWORD, false)
+        })?));
+    }
+
+    for _ in 0..options.samples {
+        let workspace = SearchIndexBenchWorkspace::create(options.threads)?;
+        workspace.maintain_index()?;
+        workspace.rewrite_incremental_thread()?;
+        incremental_refresh_ms.push(duration_ms(measure(|| workspace.maintain_index())?));
+        incremental_query_ms.push(duration_ms(measure(|| {
+            workspace.run_query(INCREMENTAL_QUERY_KEYWORD, false)
+        })?));
+    }
+
+    let cold_query_avg_ms = average(&cold_query_ms);
+    let no_index_query_avg_ms = average(&no_index_query_ms);
+    let full_build_avg_ms = average(&full_build_ms);
+    let fts_rebuild_avg_ms = average(&fts_rebuild_ms);
+    let warm_query_avg_ms = average(&warm_query_ms);
+    let incremental_refresh_avg_ms = average(&incremental_refresh_ms);
+    let incremental_query_avg_ms = average(&incremental_query_ms);
+
+    let output = json!({
+        "benchmark": "search_index",
+        "threads": options.threads,
+        "samples": options.samples,
+        "results": {
+            "cold_query_ms": cold_query_ms,
+            "no_index_query_ms": no_index_query_ms,
+            "full_build_ms": full_build_ms,
+            "fts_rebuild_ms": fts_rebuild_ms,
+            "warm_query_ms": warm_query_ms,
+            "incremental_refresh_ms": incremental_refresh_ms,
+            "incremental_query_ms": incremental_query_ms,
+        },
+        "summary": {
+            "cold_query_avg_ms": cold_query_avg_ms,
+            "no_index_query_avg_ms": no_index_query_avg_ms,
+            "full_build_avg_ms": full_build_avg_ms,
+            "fts_rebuild_avg_ms": fts_rebuild_avg_ms,
+            "warm_query_avg_ms": warm_query_avg_ms,
+            "incremental_refresh_avg_ms": incremental_refresh_avg_ms,
+            "incremental_query_avg_ms": incremental_query_avg_ms,
+            "cold_overhead_ms": cold_query_avg_ms - no_index_query_avg_ms,
+            "warm_speedup_vs_no_index": if warm_query_avg_ms > 0.0 {
+                no_index_query_avg_ms / warm_query_avg_ms
+            } else {
+                0.0
+            },
+        },
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("search index bench json must serialize")
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BenchOptions {
+    threads: usize,
+    samples: usize,
+}
+
+impl Default for BenchOptions {
+    fn default() -> Self {
+        Self {
+            threads: 2_500,
+            samples: 5,
+        }
+    }
+}
+
+impl BenchOptions {
+    fn from_args(args: impl Iterator<Item = String>) -> xurl_core::Result<Self> {
+        let mut options = Self::default();
+        let mut args = args.peekable();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--bench" => {}
+                "--threads" => {
+                    let value = args.next().ok_or_else(|| {
+                        xurl_core::XurlError::InvalidMode(
+                            "search_index bench requires a value after --threads".to_string(),
+                        )
+                    })?;
+                    options.threads = value.parse::<usize>().map_err(|_| {
+                        xurl_core::XurlError::InvalidMode(
+                            "search_index bench requires --threads to be a positive integer"
+                                .to_string(),
+                        )
+                    })?;
+                }
+                "--samples" => {
+                    let value = args.next().ok_or_else(|| {
+                        xurl_core::XurlError::InvalidMode(
+                            "search_index bench requires a value after --samples".to_string(),
+                        )
+                    })?;
+                    options.samples = value.parse::<usize>().map_err(|_| {
+                        xurl_core::XurlError::InvalidMode(
+                            "search_index bench requires --samples to be a positive integer"
+                                .to_string(),
+                        )
+                    })?;
+                }
+                other => {
+                    return Err(xurl_core::XurlError::InvalidMode(format!(
+                        "unknown search_index bench argument: {other}"
+                    )));
+                }
+            }
+        }
+
+        if options.threads == 0 {
+            return Err(xurl_core::XurlError::InvalidMode(
+                "search_index bench requires --threads >= 1".to_string(),
+            ));
+        }
+        if options.samples == 0 {
+            return Err(xurl_core::XurlError::InvalidMode(
+                "search_index bench requires --samples >= 1".to_string(),
+            ));
+        }
+
+        Ok(options)
+    }
+}
+
+struct SearchIndexBenchWorkspace {
+    _tempdir: TempDir,
+    roots: ProviderRoots,
+    index_path: PathBuf,
+    incremental_thread_path: PathBuf,
+}
+
+impl SearchIndexBenchWorkspace {
+    fn create(threads: usize) -> xurl_core::Result<Self> {
+        let tempdir = tempfile::tempdir().map_err(|source| xurl_core::XurlError::Io {
+            path: env::temp_dir(),
+            source,
+        })?;
+        let codex_root = tempdir.path().join("codex-home");
+        let index_path = tempdir.path().join("search-index.sqlite3");
+        let sessions_root = codex_root.join("sessions/2026/02/23");
+        fs::create_dir_all(&sessions_root).map_err(|source| xurl_core::XurlError::Io {
+            path: sessions_root.clone(),
+            source,
+        })?;
+        let state_db_path = codex_root.join("state.sqlite");
+
+        let incremental_thread_path = sessions_root.join(format!(
+            "rollout-2026-02-23T04-48-50-{}.jsonl",
+            bench_session_id(threads.saturating_sub(1))
+        ));
+        let scope_path = Path::new("/tmp/xurl-search-bench");
+        let mut state_rows = Vec::with_capacity(threads);
+        for index in 0..threads {
+            let session_id = bench_session_id(index);
+            let thread_path =
+                sessions_root.join(format!("rollout-2026-02-23T04-48-50-{session_id}.jsonl"));
+            let keyword = if index == 0 {
+                Some(TARGET_QUERY_KEYWORD)
+            } else {
+                None
+            };
+            write_codex_thread(&thread_path, scope_path, index, keyword)?;
+            state_rows.push((session_id, thread_path));
+        }
+        write_codex_state_db(&state_db_path, &state_rows)?;
+
+        let unused_root = tempdir.path().join("unused");
+        let roots = ProviderRoots {
+            amp_root: unused_root.join("amp"),
+            copilot_root: unused_root.join("copilot"),
+            codex_root,
+            claude_root: unused_root.join("claude"),
+            cursor_root: unused_root.join("cursor"),
+            gemini_root: unused_root.join("gemini"),
+            kimi_root: unused_root.join("kimi"),
+            pi_root: unused_root.join("pi"),
+            opencode_root: unused_root.join("opencode"),
+        };
+
+        Ok(Self {
+            _tempdir: tempdir,
+            roots,
+            index_path,
+            incremental_thread_path,
+        })
+    }
+
+    fn run_query(&self, keyword: &str, disable_index: bool) -> xurl_core::Result<()> {
+        let _index_path_guard = ScopedEnvVar::set("XURL_SEARCH_INDEX_PATH", Some(&self.index_path));
+        let _disable_index_guard = if disable_index {
+            Some(ScopedEnvVar::set(
+                "XURL_DISABLE_SEARCH_INDEX",
+                Some(Path::new("1")),
+            ))
+        } else {
+            Some(ScopedEnvVar::set(
+                "XURL_DISABLE_SEARCH_INDEX",
+                None::<&Path>,
+            ))
+        };
+        let query = ThreadQuery {
+            uri: format!("agents://codex?q={keyword}&limit=1"),
+            provider: ProviderKind::Codex,
+            role: None,
+            q: Some(keyword.to_string()),
+            limit: 1,
+            ignored_params: Vec::new(),
+        };
+        let _ = query_threads(&query, &self.roots)?;
+        Ok(())
+    }
+
+    fn maintain_index(&self) -> xurl_core::Result<()> {
+        let _index_path_guard = ScopedEnvVar::set("XURL_SEARCH_INDEX_PATH", Some(&self.index_path));
+        let _disable_index_guard = ScopedEnvVar::set("XURL_DISABLE_SEARCH_INDEX", None::<&Path>);
+        maintain_search_index_for_uri("agents://codex", &self.roots)
+    }
+
+    fn clear_search_documents(&self) -> xurl_core::Result<()> {
+        let conn =
+            Connection::open(&self.index_path).map_err(|source| xurl_core::XurlError::Sqlite {
+                path: self.index_path.clone(),
+                source,
+            })?;
+        conn.execute("DELETE FROM thread_fts", [])
+            .map_err(|source| xurl_core::XurlError::Sqlite {
+                path: self.index_path.clone(),
+                source,
+            })?;
+        Ok(())
+    }
+
+    fn rewrite_incremental_thread(&self) -> xurl_core::Result<()> {
+        write_codex_thread(
+            &self.incremental_thread_path,
+            Path::new("/tmp/xurl-search-bench"),
+            9_999_999,
+            Some(INCREMENTAL_QUERY_KEYWORD),
+        )
+    }
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: Option<impl AsRef<Path>>) -> Self {
+        let previous = env::var_os(key);
+        match value {
+            Some(value) => {
+                // SAFETY: the benchmark runs as a single-threaded process and restores the value on drop.
+                unsafe { env::set_var(key, value.as_ref()) };
+            }
+            None => {
+                // SAFETY: the benchmark runs as a single-threaded process and restores the value on drop.
+                unsafe { env::remove_var(key) };
+            }
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(previous) => {
+                // SAFETY: the benchmark runs as a single-threaded process and restores the prior value on drop.
+                unsafe { env::set_var(self.key, previous) };
+            }
+            None => {
+                // SAFETY: the benchmark runs as a single-threaded process and restores the prior value on drop.
+                unsafe { env::remove_var(self.key) };
+            }
+        }
+    }
+}
+
+fn write_codex_thread(
+    path: &Path,
+    scope_path: &Path,
+    index: usize,
+    keyword: Option<&str>,
+) -> xurl_core::Result<()> {
+    let scope = json_escape(scope_path.to_string_lossy().as_ref());
+    let keyword_suffix = keyword.map_or(String::new(), |value| format!(" {value}"));
+    let mut content = format!(
+        "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"{scope}\",\"git\":{{\"branch\":\"bench-main\"}}}}}}\n"
+    );
+    for round in 0..8 {
+        content.push_str(&format!(
+            concat!(
+                "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"user\",",
+                "\"content\":[{{\"type\":\"input_text\",\"text\":\"search corpus filler user {index}-{round} {filler}\"}}]}}}}\n",
+                "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"assistant\",",
+                "\"content\":[{{\"type\":\"output_text\",\"text\":\"search corpus filler assistant {index}-{round} {filler}\"}}]}}}}\n"
+            ),
+            index = index,
+            round = round,
+            filler = FILLER_TEXT
+        ));
+    }
+    content.push_str(&format!(
+        concat!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"user\",\"content\":[{{\"type\":\"input_text\",\"text\":\"search corpus item {index}{keyword_suffix}\"}}]}}}}\n",
+            "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{{\"type\":\"output_text\",\"text\":\"search corpus reply {index}\"}}]}}}}\n"
+        ),
+        index = index,
+        keyword_suffix = keyword_suffix
+    ));
+    fs::write(path, content).map_err(|source| xurl_core::XurlError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn write_codex_state_db(path: &Path, rows: &[(String, PathBuf)]) -> xurl_core::Result<()> {
+    let conn = Connection::open(path).map_err(|source| xurl_core::XurlError::Sqlite {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    conn.execute_batch(
+        "
+        CREATE TABLE threads (
+            id TEXT PRIMARY KEY,
+            rollout_path TEXT NOT NULL,
+            archived INTEGER NOT NULL DEFAULT 0
+        );
+        ",
+    )
+    .map_err(|source| xurl_core::XurlError::Sqlite {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut stmt = conn
+        .prepare("INSERT INTO threads (id, rollout_path, archived) VALUES (?1, ?2, 0)")
+        .map_err(|source| xurl_core::XurlError::Sqlite {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    for (session_id, rollout_path) in rows {
+        stmt.execute((session_id, rollout_path.display().to_string()))
+            .map_err(|source| xurl_core::XurlError::Sqlite {
+                path: path.to_path_buf(),
+                source,
+            })?;
+    }
+    Ok(())
+}
+
+fn bench_session_id(index: usize) -> String {
+    let value = u64::try_from(index).unwrap_or(u64::MAX).saturating_add(1);
+    format!(
+        "{:08x}-{:04x}-4000-8000-{:012x}",
+        (value >> 16) & 0xffff_ffff,
+        value & 0xffff,
+        value
+    )
+}
+
+fn json_escape(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => output.push_str("\\\\"),
+            '"' => output.push_str("\\\""),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
+fn measure(operation: impl FnOnce() -> xurl_core::Result<()>) -> xurl_core::Result<Duration> {
+    let started = Instant::now();
+    operation()?;
+    Ok(started.elapsed())
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn average(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}

--- a/xurl-core/src/lib.rs
+++ b/xurl-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod jsonl;
 pub mod model;
 pub mod provider;
 pub mod render;
+mod search_index;
 pub mod service;
 pub mod uri;
 
@@ -20,9 +21,10 @@ pub use model::{
 };
 pub use provider::{ProviderRoots, WriteEventSink};
 pub use service::{
-    query_threads, query_threads_by_path, render_path_thread_query_head_markdown,
-    render_path_thread_query_markdown, render_subagent_view_markdown, render_thread_head_markdown,
-    render_thread_markdown, render_thread_query_head_markdown, render_thread_query_markdown,
-    resolve_subagent_view, resolve_thread, write_thread,
+    maintain_search_index_for_uri, query_threads, query_threads_by_path,
+    render_path_thread_query_head_markdown, render_path_thread_query_markdown,
+    render_subagent_view_markdown, render_thread_head_markdown, render_thread_markdown,
+    render_thread_query_head_markdown, render_thread_query_markdown, resolve_subagent_view,
+    resolve_thread, write_thread,
 };
 pub use uri::AgentsUri;

--- a/xurl-core/src/model.rs
+++ b/xurl-core/src/model.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum ProviderKind {
     Amp,
     Copilot,

--- a/xurl-core/src/provider/codex.rs
+++ b/xurl-core/src/provider/codex.rs
@@ -1,5 +1,5 @@
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -26,6 +26,13 @@ pub struct CodexProvider {
 struct SqliteThreadRecord {
     rollout_path: PathBuf,
     archived: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CodexStateThreadRecord {
+    pub(crate) session_id: String,
+    pub(crate) rollout_path: PathBuf,
+    pub(crate) archived: bool,
 }
 
 impl CodexProvider {
@@ -98,6 +105,21 @@ impl CodexProvider {
         Ok(row)
     }
 
+    fn query_all_thread_records(
+        db_path: &Path,
+    ) -> std::result::Result<Vec<CodexStateThreadRecord>, rusqlite::Error> {
+        let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let mut stmt = conn.prepare("SELECT id, rollout_path, archived FROM threads")?;
+        let rows = stmt.query_map([], |row| {
+            Ok(CodexStateThreadRecord {
+                session_id: row.get::<_, String>(0)?,
+                rollout_path: PathBuf::from(row.get::<_, String>(1)?),
+                archived: row.get::<_, i64>(2)? != 0,
+            })
+        })?;
+        rows.collect()
+    }
+
     fn lookup_thread_from_state_db(
         state_dbs: &[PathBuf],
         session_id: &str,
@@ -115,6 +137,68 @@ impl CodexProvider {
         }
 
         None
+    }
+
+    pub(crate) fn collect_state_thread_records(
+        &self,
+        warnings: &mut Vec<String>,
+    ) -> Vec<CodexStateThreadRecord> {
+        let mut seen = HashSet::new();
+        let mut records = Vec::new();
+        for db_path in self.state_db_paths() {
+            match Self::query_all_thread_records(&db_path) {
+                Ok(items) => {
+                    for record in items {
+                        if !seen.insert(record.session_id.clone()) {
+                            continue;
+                        }
+                        records.push(record);
+                    }
+                }
+                Err(err) => warnings.push(format!(
+                    "failed reading sqlite thread index {}: {err}",
+                    db_path.display()
+                )),
+            }
+        }
+        records
+    }
+
+    pub(crate) fn state_manifest_watermark(&self, warnings: &mut Vec<String>) -> Option<String> {
+        let paths = self.state_db_paths();
+        if paths.is_empty() {
+            return None;
+        }
+
+        let mut parts = Vec::with_capacity(paths.len());
+        for path in paths {
+            match fs::metadata(&path) {
+                Ok(metadata) => {
+                    let modified_ns = metadata
+                        .modified()
+                        .ok()
+                        .and_then(|value| value.duration_since(SystemTime::UNIX_EPOCH).ok())
+                        .map(|value| value.as_nanos())
+                        .unwrap_or(0);
+                    parts.push(format!(
+                        "{}:{}:{}",
+                        path.display(),
+                        metadata.len(),
+                        modified_ns
+                    ));
+                }
+                Err(err) => warnings.push(format!(
+                    "failed reading codex state db metadata {}: {err}",
+                    path.display()
+                )),
+            }
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("|"))
+        }
     }
 
     fn find_candidates(root: &Path, session_id: &str) -> Vec<PathBuf> {

--- a/xurl-core/src/search_index.rs
+++ b/xurl-core/src/search_index.rs
@@ -1,0 +1,1245 @@
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dirs::home_dir;
+use rusqlite::{
+    Connection, OptionalExtension, ToSql, TransactionBehavior, params, params_from_iter,
+};
+
+use crate::error::{Result, XurlError};
+use crate::model::ProviderKind;
+
+const INDEX_SQLITE_VERSION: i64 = 3;
+const DEFAULT_WORKER_LEASE_SECS: u64 = 30;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SearchIndexKey {
+    pub provider: ProviderKind,
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PreparedMatches {
+    pub fresh_keys: HashSet<SearchIndexKey>,
+    pub matched_previews: HashMap<SearchIndexKey, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PreparedRefreshCandidates {
+    pub existing_fts_keys: HashSet<SearchIndexKey>,
+    pub fresh_keys: HashSet<SearchIndexKey>,
+    pub materialized_docs: HashMap<SearchIndexKey, OwnedSearchIndexDocument>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SearchIndexCandidate<'a> {
+    pub provider: ProviderKind,
+    pub thread_id: &'a str,
+    pub source_fingerprint: &'a str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SearchIndexDocument<'a> {
+    pub provider: ProviderKind,
+    pub thread_id: &'a str,
+    pub uri: &'a str,
+    pub thread_source: &'a str,
+    pub scope_path: Option<&'a str>,
+    pub updated_epoch: Option<u64>,
+    pub source_fingerprint: &'a str,
+    pub search_text: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OwnedSearchIndexDocument {
+    pub provider: ProviderKind,
+    pub thread_id: String,
+    pub uri: String,
+    pub thread_source: String,
+    pub scope_path: Option<String>,
+    pub updated_epoch: Option<u64>,
+    pub source_fingerprint: String,
+    pub search_text: String,
+}
+
+impl OwnedSearchIndexDocument {
+    fn as_document(&self) -> SearchIndexDocument<'_> {
+        SearchIndexDocument {
+            provider: self.provider,
+            thread_id: &self.thread_id,
+            uri: &self.uri,
+            thread_source: &self.thread_source,
+            scope_path: self.scope_path.as_deref(),
+            updated_epoch: self.updated_epoch,
+            source_fingerprint: &self.source_fingerprint,
+            search_text: &self.search_text,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IndexedMatch {
+    pub provider: ProviderKind,
+    pub thread_id: String,
+    pub uri: String,
+    pub updated_epoch: Option<u64>,
+    pub matched_preview: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderManifestEntry {
+    pub provider: ProviderKind,
+    pub thread_id: String,
+    pub uri: String,
+    pub thread_source: String,
+    pub scope_path: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SearchIndex {
+    conn: Connection,
+    path: PathBuf,
+}
+
+impl SearchIndex {
+    pub(crate) fn open_best_effort() -> (Option<Self>, Vec<String>) {
+        if search_index_disabled() {
+            return (None, Vec::new());
+        }
+
+        match Self::open() {
+            Ok(index) => (Some(index), Vec::new()),
+            Err(err) => (None, vec![format!("search index unavailable: {err}")]),
+        }
+    }
+
+    fn open() -> Result<Self> {
+        Self::open_at(search_index_path()?)
+    }
+
+    fn open_at(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| XurlError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        prepare_sqlite_cache_path(&path)?;
+
+        let conn = Connection::open(&path).map_err(|source| XurlError::Sqlite {
+            path: path.clone(),
+            source,
+        })?;
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(|source| XurlError::Sqlite {
+                path: path.clone(),
+                source,
+            })?;
+        conn.pragma_update(None, "synchronous", "NORMAL")
+            .map_err(|source| XurlError::Sqlite {
+                path: path.clone(),
+                source,
+            })?;
+        conn.pragma_update(None, "temp_store", "MEMORY")
+            .map_err(|source| XurlError::Sqlite {
+                path: path.clone(),
+                source,
+            })?;
+
+        let mut index = Self { conn, path };
+        index.ensure_schema()?;
+        Ok(index)
+    }
+
+    pub(crate) fn try_acquire_worker_lease(&mut self) -> Result<bool> {
+        let tx = self
+            .conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let now = now_epoch();
+        let current = tx
+            .query_row(
+                "SELECT value FROM xurl_meta WHERE key = 'worker_lease_until'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?
+            .and_then(|raw| raw.parse::<i64>().ok())
+            .unwrap_or(0);
+
+        if current > now {
+            tx.rollback().map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+            return Ok(false);
+        }
+
+        let lease_until = now + i64::try_from(DEFAULT_WORKER_LEASE_SECS).unwrap_or(30);
+        tx.execute(
+            "INSERT OR REPLACE INTO xurl_meta (key, value) VALUES ('worker_lease_until', ?1)",
+            [lease_until.to_string()],
+        )
+        .map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        tx.commit().map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        Ok(true)
+    }
+
+    pub(crate) fn release_worker_lease(&mut self) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM xurl_meta WHERE key = 'worker_lease_until'", [])
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        Ok(())
+    }
+
+    fn ensure_schema(&mut self) -> Result<()> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS xurl_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                 CREATE TABLE IF NOT EXISTS provider_watermarks (
+                    provider TEXT PRIMARY KEY,
+                    watermark TEXT NOT NULL,
+                    refreshed_at_epoch INTEGER NOT NULL
+                );
+                 CREATE TABLE IF NOT EXISTS provider_manifest (
+                    provider TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    uri TEXT NOT NULL,
+                    thread_source TEXT NOT NULL,
+                    scope_path TEXT,
+                    PRIMARY KEY(provider, thread_id)
+                );
+                 CREATE TABLE IF NOT EXISTS thread_materialization (
+                    provider TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    uri TEXT NOT NULL,
+                    thread_source TEXT NOT NULL,
+                    scope_path TEXT,
+                    updated_epoch INTEGER,
+                    source_fingerprint TEXT NOT NULL,
+                    materialized_at_epoch INTEGER NOT NULL,
+                    search_text TEXT NOT NULL,
+                    PRIMARY KEY(provider, thread_id)
+                );",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        self.conn
+            .execute_batch(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS thread_fts USING fts5(
+                    provider UNINDEXED,
+                    thread_id UNINDEXED,
+                    uri UNINDEXED,
+                    thread_source UNINDEXED,
+                    scope_path UNINDEXED,
+                    updated_epoch UNINDEXED,
+                    source_fingerprint UNINDEXED,
+                    indexed_at_epoch UNINDEXED,
+                    search_text,
+                    tokenize = 'trigram'
+                );",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        self.conn
+            .pragma_update(None, "user_version", INDEX_SQLITE_VERSION)
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        Ok(())
+    }
+
+    pub(crate) fn load_provider_manifest(
+        &self,
+        provider: ProviderKind,
+        watermark: &str,
+    ) -> Result<Option<Vec<ProviderManifestEntry>>> {
+        let provider = provider.to_string();
+        let current = self
+            .conn
+            .query_row(
+                "SELECT watermark FROM provider_watermarks WHERE provider = ?1",
+                [provider.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        if current.as_deref() != Some(watermark) {
+            return Ok(None);
+        }
+
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT thread_id, uri, thread_source, scope_path
+                 FROM provider_manifest
+                 WHERE provider = ?1
+                 ORDER BY thread_id",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let rows = stmt
+            .query_map([provider.as_str()], |row| {
+                Ok(ProviderManifestEntry {
+                    provider: provider_from_str(&provider).expect("valid provider"),
+                    thread_id: row.get::<_, String>(0)?,
+                    uri: row.get::<_, String>(1)?,
+                    thread_source: row.get::<_, String>(2)?,
+                    scope_path: row.get::<_, Option<String>>(3)?,
+                })
+            })
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map(Some)
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })
+    }
+
+    pub(crate) fn replace_provider_manifest(
+        &mut self,
+        provider: ProviderKind,
+        watermark: &str,
+        entries: &[ProviderManifestEntry],
+    ) -> Result<()> {
+        let provider = provider.to_string();
+        let refreshed_at_epoch = now_epoch();
+        let tx = self
+            .conn
+            .transaction()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        tx.execute(
+            "DELETE FROM provider_manifest WHERE provider = ?1",
+            [provider.as_str()],
+        )
+        .map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        {
+            let mut insert_stmt = tx
+                .prepare(
+                    "INSERT INTO provider_manifest (
+                        provider,
+                        thread_id,
+                        uri,
+                        thread_source,
+                        scope_path
+                     ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                )
+                .map_err(|source| XurlError::Sqlite {
+                    path: self.path.clone(),
+                    source,
+                })?;
+            for entry in entries {
+                insert_stmt
+                    .execute(params![
+                        provider.as_str(),
+                        &entry.thread_id,
+                        &entry.uri,
+                        &entry.thread_source,
+                        &entry.scope_path
+                    ])
+                    .map_err(|source| XurlError::Sqlite {
+                        path: self.path.clone(),
+                        source,
+                    })?;
+            }
+        }
+        tx.execute(
+            "INSERT OR REPLACE INTO provider_watermarks (
+                provider,
+                watermark,
+                refreshed_at_epoch
+             ) VALUES (?1, ?2, ?3)",
+            params![provider.as_str(), watermark, refreshed_at_epoch],
+        )
+        .map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        tx.commit().map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    pub(crate) fn is_fresh(
+        &self,
+        provider: ProviderKind,
+        thread_id: &str,
+        source_fingerprint: &str,
+    ) -> Result<bool> {
+        let provider = provider.to_string();
+        let exists = self
+            .conn
+            .query_row(
+                "SELECT 1
+                 FROM thread_fts
+                 WHERE provider = ?1
+                   AND thread_id = ?2
+                   AND source_fingerprint = ?3
+                 LIMIT 1",
+                params![provider, thread_id, source_fingerprint],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?
+            .is_some();
+        Ok(exists)
+    }
+
+    pub(crate) fn replace_document(&mut self, doc: SearchIndexDocument<'_>) -> Result<()> {
+        let tx = self
+            .conn
+            .transaction()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let path = self.path.clone();
+        let owned = OwnedSearchIndexDocument {
+            provider: doc.provider,
+            thread_id: doc.thread_id.to_string(),
+            uri: doc.uri.to_string(),
+            thread_source: doc.thread_source.to_string(),
+            scope_path: doc.scope_path.map(ToString::to_string),
+            updated_epoch: doc.updated_epoch,
+            source_fingerprint: doc.source_fingerprint.to_string(),
+            search_text: doc.search_text.to_string(),
+        };
+        Self::write_documents(&path, &tx, std::slice::from_ref(&owned), true, true)?;
+        tx.commit().map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    pub(crate) fn prepare_matches(
+        &mut self,
+        candidates: &[SearchIndexCandidate<'_>],
+        keyword: &str,
+    ) -> Result<PreparedMatches> {
+        let keyword = keyword.trim();
+        if keyword.is_empty() || keyword.chars().count() < 3 || candidates.is_empty() {
+            return Ok(PreparedMatches::default());
+        }
+
+        self.load_query_candidates(candidates)?;
+
+        let fresh_keys = self.query_fresh_keys()?;
+        let matched_previews = self.query_matched_previews(keyword)?;
+        Ok(PreparedMatches {
+            fresh_keys,
+            matched_previews,
+        })
+    }
+
+    pub(crate) fn query_matches(
+        &self,
+        provider: ProviderKind,
+        keyword: &str,
+        scope_path_prefix: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<IndexedMatch>> {
+        let keyword = keyword.trim();
+        if keyword.is_empty() || keyword.chars().count() < 3 || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let like = format!("%{}%", escape_like(keyword));
+        let provider = provider.to_string();
+        let sql = if scope_path_prefix.is_some() {
+            "SELECT provider, thread_id, uri, updated_epoch, search_text
+             FROM thread_fts
+             WHERE provider = ?1
+               AND search_text LIKE ?2 ESCAPE '\\'
+               AND (scope_path = ?3 OR scope_path LIKE ?4 ESCAPE '\\')
+             ORDER BY updated_epoch DESC
+             LIMIT ?5"
+        } else {
+            "SELECT provider, thread_id, uri, updated_epoch, search_text
+             FROM thread_fts
+             WHERE provider = ?1
+               AND search_text LIKE ?2 ESCAPE '\\'
+             ORDER BY updated_epoch DESC
+             LIMIT ?3"
+        };
+
+        let mut owned = vec![
+            rusqlite::types::Value::from(provider),
+            rusqlite::types::Value::from(like),
+        ];
+        if let Some(scope_path_prefix) = scope_path_prefix {
+            let escaped = escape_like(scope_path_prefix);
+            owned.push(rusqlite::types::Value::from(scope_path_prefix.to_string()));
+            owned.push(rusqlite::types::Value::from(format!("{escaped}/%")));
+        }
+        owned.push(rusqlite::types::Value::from(
+            i64::try_from(limit).unwrap_or(i64::MAX),
+        ));
+        let params = owned.iter().map(|value| value as &dyn ToSql);
+
+        let mut stmt = self.conn.prepare(sql).map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        let rows = stmt
+            .query_map(params_from_iter(params), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<i64>>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        let mut matches = Vec::new();
+        for row in rows {
+            let (provider, thread_id, uri, updated_epoch, search_text) =
+                row.map_err(|source| XurlError::Sqlite {
+                    path: self.path.clone(),
+                    source,
+                })?;
+            let Some(provider) = provider_from_str(&provider) else {
+                continue;
+            };
+            let Some(matched_preview) =
+                super::service::match_first_preview_in_text(&search_text, keyword)
+            else {
+                continue;
+            };
+            matches.push(IndexedMatch {
+                provider,
+                thread_id,
+                uri,
+                updated_epoch: updated_epoch.and_then(|value| u64::try_from(value).ok()),
+                matched_preview,
+            });
+        }
+
+        Ok(matches)
+    }
+
+    pub(crate) fn prepare_refresh_candidates(
+        &mut self,
+        candidates: &[SearchIndexCandidate<'_>],
+    ) -> Result<PreparedRefreshCandidates> {
+        if candidates.is_empty() {
+            return Ok(PreparedRefreshCandidates::default());
+        }
+        self.load_query_candidates(candidates)?;
+        let fresh_keys = self.query_fresh_keys()?;
+        let stale_candidates = candidates
+            .iter()
+            .copied()
+            .filter(|candidate| {
+                !fresh_keys.contains(&SearchIndexKey {
+                    provider: candidate.provider,
+                    thread_id: candidate.thread_id.to_string(),
+                })
+            })
+            .collect::<Vec<_>>();
+        let materialized_docs = if stale_candidates.is_empty() {
+            HashMap::new()
+        } else {
+            self.load_query_candidates(&stale_candidates)?;
+            self.query_materialized_documents()?
+        };
+        Ok(PreparedRefreshCandidates {
+            existing_fts_keys: self.query_existing_fts_keys()?,
+            fresh_keys,
+            materialized_docs,
+        })
+    }
+
+    pub(crate) fn insert_documents(&mut self, docs: &[OwnedSearchIndexDocument]) -> Result<()> {
+        self.write_documents_with_mode(docs, true, false)
+    }
+
+    pub(crate) fn replace_documents(&mut self, docs: &[OwnedSearchIndexDocument]) -> Result<()> {
+        self.write_documents_with_mode(docs, true, true)
+    }
+
+    pub(crate) fn insert_materialized_documents(
+        &mut self,
+        docs: &[OwnedSearchIndexDocument],
+    ) -> Result<()> {
+        self.write_documents_with_mode(docs, false, false)
+    }
+
+    pub(crate) fn replace_materialized_documents(
+        &mut self,
+        docs: &[OwnedSearchIndexDocument],
+    ) -> Result<()> {
+        self.write_documents_with_mode(docs, false, true)
+    }
+
+    fn write_documents_with_mode(
+        &mut self,
+        docs: &[OwnedSearchIndexDocument],
+        persist_materialization: bool,
+        replace_existing: bool,
+    ) -> Result<()> {
+        if docs.is_empty() {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .transaction()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let path = self.path.clone();
+        Self::write_documents(&path, &tx, docs, persist_materialization, replace_existing)?;
+        tx.commit().map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    fn write_documents(
+        path: &Path,
+        tx: &rusqlite::Transaction<'_>,
+        docs: &[OwnedSearchIndexDocument],
+        persist_materialization: bool,
+        replace_existing: bool,
+    ) -> Result<()> {
+        let mut delete_fts_stmt = if replace_existing {
+            Some(
+                tx.prepare("DELETE FROM thread_fts WHERE provider = ?1 AND thread_id = ?2")
+                    .map_err(|source| XurlError::Sqlite {
+                        path: path.to_path_buf(),
+                        source,
+                    })?,
+            )
+        } else {
+            None
+        };
+        let mut insert_fts_stmt = tx
+            .prepare(
+                "INSERT INTO thread_fts (
+                    provider,
+                    thread_id,
+                    uri,
+                    thread_source,
+                    scope_path,
+                    updated_epoch,
+                    source_fingerprint,
+                    indexed_at_epoch,
+                    search_text
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let mut insert_materialization_stmt = if persist_materialization {
+            Some(
+                tx.prepare(
+                    "INSERT OR REPLACE INTO thread_materialization (
+                        provider,
+                        thread_id,
+                        uri,
+                        thread_source,
+                        scope_path,
+                        updated_epoch,
+                        source_fingerprint,
+                        materialized_at_epoch,
+                        search_text
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                )
+                .map_err(|source| XurlError::Sqlite {
+                    path: path.to_path_buf(),
+                    source,
+                })?,
+            )
+        } else {
+            None
+        };
+        let indexed_at_epoch = now_epoch();
+        let materialized_at_epoch = indexed_at_epoch;
+        for doc in docs {
+            let doc = doc.as_document();
+            let provider = doc.provider.to_string();
+            let updated_epoch = doc
+                .updated_epoch
+                .and_then(|value| i64::try_from(value).ok());
+            if let Some(delete_fts_stmt) = delete_fts_stmt.as_mut() {
+                delete_fts_stmt
+                    .execute(params![provider, doc.thread_id])
+                    .map_err(|source| XurlError::Sqlite {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+            }
+            insert_fts_stmt
+                .execute(params![
+                    provider,
+                    doc.thread_id,
+                    doc.uri,
+                    doc.thread_source,
+                    doc.scope_path,
+                    updated_epoch,
+                    doc.source_fingerprint,
+                    indexed_at_epoch,
+                    doc.search_text
+                ])
+                .map_err(|source| XurlError::Sqlite {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+            if let Some(insert_materialization_stmt) = insert_materialization_stmt.as_mut() {
+                insert_materialization_stmt
+                    .execute(params![
+                        provider,
+                        doc.thread_id,
+                        doc.uri,
+                        doc.thread_source,
+                        doc.scope_path,
+                        updated_epoch,
+                        doc.source_fingerprint,
+                        materialized_at_epoch,
+                        doc.search_text
+                    ])
+                    .map_err(|source| XurlError::Sqlite {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn query_fresh_keys(&self) -> Result<HashSet<SearchIndexKey>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT DISTINCT f.provider, f.thread_id
+                 FROM query_candidates q
+                 JOIN thread_fts f
+                   ON f.provider = q.provider
+                  AND f.thread_id = q.thread_id
+                  AND f.source_fingerprint = q.source_fingerprint",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        let mut keys = HashSet::new();
+        for row in rows {
+            let (provider, thread_id) = row.map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+            if let Some(provider) = provider_from_str(&provider) {
+                keys.insert(SearchIndexKey {
+                    provider,
+                    thread_id,
+                });
+            }
+        }
+
+        Ok(keys)
+    }
+
+    fn query_existing_fts_keys(&self) -> Result<HashSet<SearchIndexKey>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT DISTINCT f.provider, f.thread_id
+                 FROM query_candidates q
+                 JOIN thread_fts f
+                   ON f.provider = q.provider
+                  AND f.thread_id = q.thread_id",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        let mut keys = HashSet::new();
+        for row in rows {
+            let (provider, thread_id) = row.map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+            if let Some(provider) = provider_from_str(&provider) {
+                keys.insert(SearchIndexKey {
+                    provider,
+                    thread_id,
+                });
+            }
+        }
+
+        Ok(keys)
+    }
+
+    fn query_matched_previews(&self, keyword: &str) -> Result<HashMap<SearchIndexKey, String>> {
+        let like = format!("%{}%", escape_like(keyword));
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT DISTINCT f.provider, f.thread_id, f.search_text
+                 FROM query_candidates q
+                 JOIN thread_fts f
+                   ON f.provider = q.provider
+                  AND f.thread_id = q.thread_id
+                  AND f.source_fingerprint = q.source_fingerprint
+                 WHERE f.search_text LIKE ?1 ESCAPE '\\'",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let rows = stmt
+            .query_map([like], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        let mut matches = HashMap::new();
+        for row in rows {
+            let (provider, thread_id, search_text) = row.map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+            let Some(provider) = provider_from_str(&provider) else {
+                continue;
+            };
+            if let Some(preview) =
+                super::service::match_first_preview_in_text(&search_text, keyword)
+            {
+                matches.insert(
+                    SearchIndexKey {
+                        provider,
+                        thread_id,
+                    },
+                    preview,
+                );
+            }
+        }
+
+        Ok(matches)
+    }
+
+    fn query_materialized_documents(
+        &self,
+    ) -> Result<HashMap<SearchIndexKey, OwnedSearchIndexDocument>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT DISTINCT m.provider, m.thread_id, m.uri, m.thread_source, m.scope_path,
+                        m.updated_epoch, m.source_fingerprint, m.search_text
+                 FROM query_candidates q
+                 JOIN thread_materialization m
+                   ON m.provider = q.provider
+                  AND m.thread_id = q.thread_id
+                  AND m.source_fingerprint = q.source_fingerprint",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<i64>>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, String>(7)?,
+                ))
+            })
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        let mut docs = HashMap::new();
+        for row in rows {
+            let (
+                provider,
+                thread_id,
+                uri,
+                thread_source,
+                scope_path,
+                updated_epoch,
+                source_fingerprint,
+                search_text,
+            ) = row.map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+            let Some(provider) = provider_from_str(&provider) else {
+                continue;
+            };
+            let key = SearchIndexKey {
+                provider,
+                thread_id: thread_id.clone(),
+            };
+            docs.insert(
+                key,
+                OwnedSearchIndexDocument {
+                    provider,
+                    thread_id,
+                    uri,
+                    thread_source,
+                    scope_path,
+                    updated_epoch: updated_epoch.and_then(|value| u64::try_from(value).ok()),
+                    source_fingerprint,
+                    search_text,
+                },
+            );
+        }
+
+        Ok(docs)
+    }
+
+    fn load_query_candidates(&mut self, candidates: &[SearchIndexCandidate<'_>]) -> Result<()> {
+        self.conn
+            .execute_batch(
+                "CREATE TEMP TABLE IF NOT EXISTS query_candidates (
+                    provider TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    source_fingerprint TEXT NOT NULL
+                );
+                 DELETE FROM query_candidates;",
+            )
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+
+        let tx = self
+            .conn
+            .transaction()
+            .map_err(|source| XurlError::Sqlite {
+                path: self.path.clone(),
+                source,
+            })?;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "INSERT INTO query_candidates (provider, thread_id, source_fingerprint)
+                     VALUES (?1, ?2, ?3)",
+                )
+                .map_err(|source| XurlError::Sqlite {
+                    path: self.path.clone(),
+                    source,
+                })?;
+
+            for candidate in candidates {
+                stmt.execute(params![
+                    candidate.provider.to_string(),
+                    candidate.thread_id,
+                    candidate.source_fingerprint
+                ])
+                .map_err(|source| XurlError::Sqlite {
+                    path: self.path.clone(),
+                    source,
+                })?;
+            }
+        }
+        tx.commit().map_err(|source| XurlError::Sqlite {
+            path: self.path.clone(),
+            source,
+        })?;
+        Ok(())
+    }
+}
+
+fn prepare_sqlite_cache_path(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let conn = match Connection::open(path) {
+        Ok(conn) => conn,
+        Err(_) => {
+            remove_sqlite_cache_family(path)?;
+            return Ok(());
+        }
+    };
+    let version = conn
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+        .unwrap_or_default();
+    drop(conn);
+
+    if version != INDEX_SQLITE_VERSION {
+        remove_sqlite_cache_family(path)?;
+    }
+
+    Ok(())
+}
+
+fn remove_sqlite_cache_family(path: &Path) -> Result<()> {
+    for candidate in sqlite_cache_family_paths(path) {
+        if let Err(source) = fs::remove_file(&candidate)
+            && source.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(XurlError::Io {
+                path: candidate,
+                source,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn sqlite_cache_family_paths(path: &Path) -> [PathBuf; 3] {
+    let base = path.to_string_lossy();
+    [
+        path.to_path_buf(),
+        PathBuf::from(format!("{base}-wal")),
+        PathBuf::from(format!("{base}-shm")),
+    ]
+}
+
+fn search_index_disabled() -> bool {
+    env::var_os("XURL_DISABLE_SEARCH_INDEX")
+        .filter(|value| !value.is_empty() && value != "0")
+        .is_some()
+}
+
+fn search_index_path() -> Result<PathBuf> {
+    if let Some(path) = env::var_os("XURL_SEARCH_INDEX_PATH").filter(|path| !path.is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+
+    let home = home_dir().ok_or(XurlError::HomeDirectoryNotFound)?;
+    let state_root = env::var_os("XDG_STATE_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".local/state"));
+    Ok(state_root.join("xurl/search-index-v1.sqlite3"))
+}
+
+fn now_epoch() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+fn provider_from_str(raw: &str) -> Option<ProviderKind> {
+    match raw {
+        "amp" => Some(ProviderKind::Amp),
+        "copilot" => Some(ProviderKind::Copilot),
+        "codex" => Some(ProviderKind::Codex),
+        "claude" => Some(ProviderKind::Claude),
+        "cursor" => Some(ProviderKind::Cursor),
+        "gemini" => Some(ProviderKind::Gemini),
+        "kimi" => Some(ProviderKind::Kimi),
+        "pi" => Some(ProviderKind::Pi),
+        "opencode" => Some(ProviderKind::Opencode),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recreates_outdated_database_before_open() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("search-index.sqlite3");
+        let conn = Connection::open(&path).expect("open sqlite");
+        conn.pragma_update(None, "user_version", 1_i64)
+            .expect("set old version");
+        conn.execute("CREATE TABLE stale (id INTEGER PRIMARY KEY)", [])
+            .expect("create stale table");
+        drop(conn);
+
+        let index = SearchIndex::open_at(path.clone()).expect("open search index");
+        drop(index);
+
+        let conn = Connection::open(&path).expect("reopen sqlite");
+        let user_version = conn
+            .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+            .expect("read user_version");
+        let stale_exists = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'stale'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("query sqlite_master");
+
+        assert_eq!(user_version, INDEX_SQLITE_VERSION);
+        assert_eq!(stale_exists, 0);
+    }
+
+    #[test]
+    fn round_trips_provider_manifest() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("search-index.sqlite3");
+        let mut index = SearchIndex::open_at(path).expect("open search index");
+        let entry = ProviderManifestEntry {
+            provider: ProviderKind::Codex,
+            thread_id: "thread-1".to_string(),
+            uri: "agents://codex/thread-1".to_string(),
+            thread_source: "/tmp/thread-1.jsonl".to_string(),
+            scope_path: Some("/tmp/workspace".to_string()),
+        };
+
+        index
+            .replace_provider_manifest(
+                ProviderKind::Codex,
+                "watermark-1",
+                std::slice::from_ref(&entry),
+            )
+            .expect("replace provider manifest");
+
+        let loaded = index
+            .load_provider_manifest(ProviderKind::Codex, "watermark-1")
+            .expect("load provider manifest");
+        let stale = index
+            .load_provider_manifest(ProviderKind::Codex, "watermark-2")
+            .expect("load stale provider manifest");
+
+        assert_eq!(loaded, Some(vec![entry]));
+        assert_eq!(stale, None);
+    }
+
+    #[test]
+    fn reuses_materialized_document_when_fts_rows_are_missing() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("search-index.sqlite3");
+        let mut index = SearchIndex::open_at(path).expect("open search index");
+        index
+            .replace_document(SearchIndexDocument {
+                provider: ProviderKind::Codex,
+                thread_id: "thread-1",
+                uri: "agents://codex/thread-1",
+                thread_source: "/tmp/thread-1.jsonl",
+                scope_path: Some("/tmp/workspace"),
+                updated_epoch: Some(42),
+                source_fingerprint: "file:42:1024",
+                search_text: "hello materialized world",
+            })
+            .expect("replace search document");
+
+        index
+            .conn
+            .execute("DELETE FROM thread_fts", [])
+            .expect("delete thread fts rows");
+
+        let prepared = index
+            .prepare_refresh_candidates(&[SearchIndexCandidate {
+                provider: ProviderKind::Codex,
+                thread_id: "thread-1",
+                source_fingerprint: "file:42:1024",
+            }])
+            .expect("prepare refresh candidates");
+
+        assert!(prepared.fresh_keys.is_empty());
+        assert_eq!(
+            prepared.materialized_docs.get(&SearchIndexKey {
+                provider: ProviderKind::Codex,
+                thread_id: "thread-1".to_string(),
+            }),
+            Some(&OwnedSearchIndexDocument {
+                provider: ProviderKind::Codex,
+                thread_id: "thread-1".to_string(),
+                uri: "agents://codex/thread-1".to_string(),
+                thread_source: "/tmp/thread-1.jsonl".to_string(),
+                scope_path: Some("/tmp/workspace".to_string()),
+                updated_epoch: Some(42),
+                source_fingerprint: "file:42:1024".to_string(),
+                search_text: "hello materialized world".to_string(),
+            })
+        );
+    }
+}

--- a/xurl-core/src/service.rs
+++ b/xurl-core/src/service.rs
@@ -1,5 +1,5 @@
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -23,7 +23,7 @@ use crate::model::{
 };
 use crate::provider::amp::AmpProvider;
 use crate::provider::claude::ClaudeProvider;
-use crate::provider::codex::CodexProvider;
+use crate::provider::codex::{CodexProvider, CodexStateThreadRecord};
 use crate::provider::copilot::CopilotProvider;
 use crate::provider::cursor::CursorProvider;
 use crate::provider::gemini::GeminiProvider;
@@ -32,7 +32,14 @@ use crate::provider::opencode::OpencodeProvider;
 use crate::provider::pi::PiProvider;
 use crate::provider::{Provider, ProviderRoots, WriteEventSink};
 use crate::render;
-use crate::uri::{AgentsUri, is_uuid_session_id};
+use crate::search_index::{
+    IndexedMatch, OwnedSearchIndexDocument, PreparedMatches, ProviderManifestEntry, SearchIndex,
+    SearchIndexCandidate, SearchIndexDocument, SearchIndexKey,
+};
+use crate::uri::{
+    AgentsUri, is_uuid_session_id, parse_collection_query_uri, parse_path_query_uri,
+    parse_role_query_uri,
+};
 
 const STATUS_PENDING_INIT: &str = "pendingInit";
 const STATUS_RUNNING: &str = "running";
@@ -187,7 +194,7 @@ pub fn write_thread(
     req: &WriteRequest,
     sink: &mut dyn WriteEventSink,
 ) -> Result<WriteResult> {
-    match provider {
+    let result = match provider {
         ProviderKind::Amp => AmpProvider::new(&roots.amp_root).write(req, sink),
         ProviderKind::Copilot => CopilotProvider::new(&roots.copilot_root).write(req, sink),
         ProviderKind::Codex => CodexProvider::new(&roots.codex_root).write(req, sink),
@@ -197,7 +204,10 @@ pub fn write_thread(
         ProviderKind::Kimi => Err(XurlError::UnsupportedProviderWrite("kimi".to_string())),
         ProviderKind::Pi => PiProvider::new(&roots.pi_root).write(req, sink),
         ProviderKind::Opencode => OpencodeProvider::new(&roots.opencode_root).write(req, sink),
-    }
+    }?;
+
+    let _ = refresh_index_for_provider_session(provider, roots, &result.session_id);
+    Ok(result)
 }
 
 #[derive(Debug, Clone)]
@@ -214,6 +224,7 @@ struct QueryCandidate {
     thread_source: String,
     updated_at: Option<String>,
     updated_epoch: Option<u64>,
+    source_fingerprint: String,
     scope_path: Option<PathBuf>,
     search_target: QuerySearchTarget,
 }
@@ -224,6 +235,14 @@ pub fn query_threads(query: &ThreadQuery, roots: &ProviderRoots) -> Result<Threa
         .iter()
         .map(|key| format!("ignored query parameter: {key}"))
         .collect::<Vec<_>>();
+
+    if let Some(items) = try_query_threads_fast_path(query, roots)? {
+        return Ok(ThreadQueryResult {
+            query: query.clone(),
+            items,
+            warnings,
+        });
+    }
 
     let mut candidates = match query.provider {
         ProviderKind::Amp => collect_amp_query_candidates(roots, &mut warnings),
@@ -269,6 +288,12 @@ pub fn query_threads(query: &ThreadQuery, roots: &ProviderRoots) -> Result<Threa
         .map(str::trim)
         .filter(|q| !q.is_empty());
     let keyword_filter = query.q.as_deref().map(str::trim).filter(|q| !q.is_empty());
+    let (mut search_index, index_warnings) = SearchIndex::open_best_effort();
+    warnings.extend(index_warnings);
+    let prepared_role_matches =
+        prepare_indexed_matches(search_index.as_mut(), &candidates, role_filter)?;
+    let prepared_keyword_matches =
+        prepare_indexed_matches(search_index.as_mut(), &candidates, keyword_filter)?;
     let mut items = Vec::new();
     for candidate in &candidates {
         if items.len() >= query.limit {
@@ -277,14 +302,22 @@ pub fn query_threads(query: &ThreadQuery, roots: &ProviderRoots) -> Result<Threa
 
         let mut role_preview = None::<String>;
         if let Some(role_filter) = role_filter {
-            role_preview = match_candidate_preview(candidate, role_filter)?;
+            role_preview = match_candidate_preview_with_index(
+                candidate,
+                role_filter,
+                prepared_role_matches.as_ref(),
+            )?;
             if role_preview.is_none() {
                 continue;
             }
         }
 
         let matched_preview = if let Some(keyword_filter) = keyword_filter {
-            let matched_preview = match_candidate_preview(candidate, keyword_filter)?;
+            let matched_preview = match_candidate_preview_with_index(
+                candidate,
+                keyword_filter,
+                prepared_keyword_matches.as_ref(),
+            )?;
             if matched_preview.is_none() {
                 continue;
             }
@@ -329,6 +362,15 @@ pub fn query_threads_by_path(
     let providers = query.providers.clone().unwrap_or_else(all_provider_kinds);
     let keyword_filter = query.q.as_deref().map(str::trim).filter(|q| !q.is_empty());
     let requested_path = PathBuf::from(&query.scope_path);
+
+    if let Some(items) = try_query_threads_by_path_fast_path(query, roots, &requested_path)? {
+        return Ok(PathThreadQueryResult {
+            query: query.clone(),
+            items,
+            warnings,
+        });
+    }
+
     let mut candidates = Vec::new();
     for provider in providers.iter().copied() {
         candidates.extend(collect_candidates_for_provider(
@@ -346,6 +388,10 @@ pub fn query_threads_by_path(
             .is_some_and(|scope_path| path_matches_scope(scope_path, &requested_path))
     });
     candidates.sort_by_key(|candidate| Reverse(candidate.updated_epoch.unwrap_or(0)));
+    let (mut search_index, index_warnings) = SearchIndex::open_best_effort();
+    warnings.extend(index_warnings);
+    let prepared_keyword_matches =
+        prepare_indexed_matches(search_index.as_mut(), &candidates, keyword_filter)?;
 
     if query.limit == 0 {
         return Ok(PathThreadQueryResult {
@@ -362,7 +408,11 @@ pub fn query_threads_by_path(
         }
 
         let matched_preview = if let Some(keyword_filter) = keyword_filter {
-            let matched_preview = match_candidate_preview(candidate, keyword_filter)?;
+            let matched_preview = match_candidate_preview_with_index(
+                candidate,
+                keyword_filter,
+                prepared_keyword_matches.as_ref(),
+            )?;
             if matched_preview.is_none() {
                 continue;
             }
@@ -391,6 +441,157 @@ pub fn query_threads_by_path(
         query: query.clone(),
         items,
         warnings,
+    })
+}
+
+pub fn maintain_search_index_for_uri(input: &str, roots: &ProviderRoots) -> Result<()> {
+    let (mut search_index, _) = SearchIndex::open_best_effort();
+    let Some(search_index) = search_index.as_mut() else {
+        return Ok(());
+    };
+    if !search_index.try_acquire_worker_lease()? {
+        return Ok(());
+    }
+
+    let result = maintain_search_index_for_uri_locked(input, roots, search_index);
+    let release_result = search_index.release_worker_lease();
+    result?;
+    release_result?;
+    Ok(())
+}
+
+fn maintain_search_index_for_uri_locked(
+    input: &str,
+    roots: &ProviderRoots,
+    search_index: &mut SearchIndex,
+) -> Result<()> {
+    if let Some(query) = parse_path_query_uri(input)? {
+        let providers = query.providers.unwrap_or_else(all_provider_kinds);
+        let requested_path = PathBuf::from(&query.scope_path);
+        let mut warnings = Vec::new();
+        let mut candidates = Vec::new();
+        for provider in providers {
+            let provider_candidates = if provider == ProviderKind::Codex {
+                collect_codex_index_candidates(roots, &mut warnings, search_index)?
+            } else {
+                collect_candidates_for_provider(provider, roots, &mut warnings, true)?
+            };
+            candidates.extend(provider_candidates);
+        }
+        candidates.retain(|candidate| {
+            candidate
+                .scope_path
+                .as_deref()
+                .is_some_and(|scope_path| path_matches_scope(scope_path, &requested_path))
+        });
+        return refresh_candidates_search_index(&candidates, search_index);
+    }
+
+    if let Some(query) = parse_collection_query_uri(input)? {
+        let mut warnings = Vec::new();
+        let candidates = if query.provider == ProviderKind::Codex {
+            collect_codex_index_candidates(roots, &mut warnings, search_index)?
+        } else {
+            collect_candidates_for_provider(query.provider, roots, &mut warnings, true)?
+        };
+        return refresh_candidates_search_index(&candidates, search_index);
+    }
+
+    if let Some(query) = parse_role_query_uri(input)? {
+        let mut warnings = Vec::new();
+        let candidates = if query.provider == ProviderKind::Codex {
+            collect_codex_index_candidates(roots, &mut warnings, search_index)?
+        } else {
+            collect_candidates_for_provider(query.provider, roots, &mut warnings, true)?
+        };
+        return refresh_candidates_search_index(&candidates, search_index);
+    }
+
+    let mut uri = AgentsUri::parse(input)?;
+    if uri.agent_id.is_some() {
+        uri = main_thread_uri(&uri);
+    }
+    if uri.is_collection() {
+        return Ok(());
+    }
+
+    let resolved = resolve_thread(&uri, roots)?;
+    refresh_resolved_thread_search_index(&resolved)
+}
+
+fn refresh_candidates_search_index(
+    candidates: &[QueryCandidate],
+    search_index: &mut SearchIndex,
+) -> Result<()> {
+    let candidate_rows = candidates
+        .iter()
+        .map(|candidate| SearchIndexCandidate {
+            provider: candidate.provider,
+            thread_id: &candidate.thread_id,
+            source_fingerprint: &candidate.source_fingerprint,
+        })
+        .collect::<Vec<_>>();
+    let prepared = search_index.prepare_refresh_candidates(&candidate_rows)?;
+    let stale_candidates = candidates
+        .iter()
+        .filter(|candidate| {
+            let key = SearchIndexKey {
+                provider: candidate.provider,
+                thread_id: candidate.thread_id.clone(),
+            };
+            !prepared.fresh_keys.contains(&key)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut cached_insert_docs = Vec::new();
+    let mut cached_replace_docs = Vec::new();
+    let mut built_insert_docs = Vec::new();
+    let mut built_replace_docs = Vec::new();
+    for candidate in &stale_candidates {
+        let key = SearchIndexKey {
+            provider: candidate.provider,
+            thread_id: candidate.thread_id.clone(),
+        };
+        let exists_in_fts = prepared.existing_fts_keys.contains(&key);
+        if let Some(doc) = prepared.materialized_docs.get(&key) {
+            if exists_in_fts {
+                cached_replace_docs.push(doc.clone());
+            } else {
+                cached_insert_docs.push(doc.clone());
+            }
+        } else {
+            let doc = build_owned_search_index_document(candidate)?;
+            if exists_in_fts {
+                built_replace_docs.push(doc);
+            } else {
+                built_insert_docs.push(doc);
+            }
+        }
+    }
+    search_index.insert_materialized_documents(&cached_insert_docs)?;
+    search_index.replace_materialized_documents(&cached_replace_docs)?;
+    search_index.insert_documents(&built_insert_docs)?;
+    search_index.replace_documents(&built_replace_docs)?;
+    Ok(())
+}
+
+fn build_owned_search_index_document(
+    candidate: &QueryCandidate,
+) -> Result<OwnedSearchIndexDocument> {
+    let search_text = build_candidate_search_text(candidate)?;
+    Ok(OwnedSearchIndexDocument {
+        provider: candidate.provider,
+        thread_id: candidate.thread_id.clone(),
+        uri: candidate.uri.clone(),
+        thread_source: candidate.thread_source.clone(),
+        scope_path: candidate
+            .scope_path
+            .clone()
+            .or_else(|| extract_scope_path_from_raw(candidate.provider, &search_text))
+            .and_then(|path| path.to_str().map(ToString::to_string)),
+        updated_epoch: candidate.updated_epoch,
+        source_fingerprint: candidate.source_fingerprint.clone(),
+        search_text,
     })
 }
 
@@ -559,6 +760,253 @@ fn match_candidate_preview(candidate: &QueryCandidate, keyword: &str) -> Result<
     }
 }
 
+fn try_query_threads_fast_path(
+    query: &ThreadQuery,
+    roots: &ProviderRoots,
+) -> Result<Option<Vec<ThreadQueryItem>>> {
+    if query.limit == 0 {
+        return Ok(None);
+    }
+    let query_filter =
+        QueryFastPathFilter::from_terms(query.q.as_deref(), query.role.as_deref(), None);
+    let Some(query_filter) = query_filter else {
+        return Ok(None);
+    };
+
+    let (search_index, _) = SearchIndex::open_best_effort();
+    let Some(search_index) = search_index.as_ref() else {
+        return Ok(None);
+    };
+    let indexed_matches = search_index.query_matches(
+        query.provider,
+        query_filter.primary_filter,
+        None,
+        fast_path_search_limit(query.limit),
+    )?;
+    build_fast_path_items(indexed_matches, roots, &query_filter, query.limit)
+}
+
+fn try_query_threads_by_path_fast_path(
+    query: &PathThreadQuery,
+    roots: &ProviderRoots,
+    requested_path: &Path,
+) -> Result<Option<Vec<ThreadQueryItem>>> {
+    if query.limit == 0 {
+        return Ok(None);
+    }
+    let query_filter =
+        QueryFastPathFilter::from_terms(query.q.as_deref(), None, Some(requested_path));
+    let Some(query_filter) = query_filter else {
+        return Ok(None);
+    };
+
+    let (search_index, _) = SearchIndex::open_best_effort();
+    let Some(search_index) = search_index.as_ref() else {
+        return Ok(None);
+    };
+    let mut indexed_matches = Vec::new();
+    for provider in &query.providers.clone().unwrap_or_else(all_provider_kinds) {
+        indexed_matches.extend(search_index.query_matches(
+            *provider,
+            query_filter.primary_filter,
+            query_filter.scope_path_prefix,
+            fast_path_search_limit(query.limit),
+        )?);
+    }
+    indexed_matches.sort_by_key(|candidate| Reverse(candidate.updated_epoch.unwrap_or(0)));
+    build_fast_path_items(indexed_matches, roots, &query_filter, query.limit)
+}
+
+fn build_fast_path_items(
+    indexed_matches: Vec<IndexedMatch>,
+    roots: &ProviderRoots,
+    query_filter: &QueryFastPathFilter<'_>,
+    limit: usize,
+) -> Result<Option<Vec<ThreadQueryItem>>> {
+    if indexed_matches.is_empty() {
+        return Ok(None);
+    }
+
+    let mut seen = HashSet::new();
+    let mut items = Vec::new();
+    for indexed_match in indexed_matches {
+        let key = (indexed_match.provider, indexed_match.thread_id.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        if let Some(item) = materialize_indexed_match(&indexed_match, roots, query_filter)? {
+            items.push(item);
+            if items.len() >= limit {
+                return Ok(Some(items));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn materialize_indexed_match(
+    indexed_match: &IndexedMatch,
+    roots: &ProviderRoots,
+    query_filter: &QueryFastPathFilter<'_>,
+) -> Result<Option<ThreadQueryItem>> {
+    let resolved = match resolve_thread_for_provider_session(
+        indexed_match.provider,
+        roots,
+        &indexed_match.thread_id,
+    ) {
+        Ok(resolved) => resolved,
+        Err(_) => return Ok(None),
+    };
+    if query_filter
+        .scope_path
+        .is_some_and(|scope_path| !resolved_thread_matches_scope(&resolved, scope_path))
+    {
+        return Ok(None);
+    }
+    let raw = read_thread_raw(&resolved.path)?;
+
+    if query_filter
+        .secondary_filter
+        .is_some_and(|filter| match_first_preview_in_text(&raw, filter).is_none())
+    {
+        return Ok(None);
+    }
+    let matched_preview = if let Some(preview_filter) = query_filter.preview_filter {
+        match_first_preview_in_text(&raw, preview_filter)
+    } else {
+        Some(indexed_match.matched_preview.clone())
+    };
+    let Some(matched_preview) = matched_preview else {
+        return Ok(None);
+    };
+
+    Ok(Some(ThreadQueryItem {
+        provider: indexed_match.provider,
+        thread_id: indexed_match.thread_id.clone(),
+        uri: indexed_match.uri.clone(),
+        thread_source: resolved.path.display().to_string(),
+        updated_at: modified_timestamp_string(&resolved.path),
+        matched_preview: Some(matched_preview),
+        thread_metadata: collect_query_thread_metadata(indexed_match.provider, &resolved.path),
+    }))
+}
+
+fn fast_path_search_limit(limit: usize) -> usize {
+    limit.saturating_mul(16).max(limit.saturating_add(32))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct QueryFastPathFilter<'a> {
+    primary_filter: &'a str,
+    secondary_filter: Option<&'a str>,
+    preview_filter: Option<&'a str>,
+    scope_path: Option<&'a Path>,
+    scope_path_prefix: Option<&'a str>,
+}
+
+impl<'a> QueryFastPathFilter<'a> {
+    fn from_terms(
+        keyword: Option<&'a str>,
+        role: Option<&'a str>,
+        scope_path: Option<&'a Path>,
+    ) -> Option<Self> {
+        let keyword = keyword.map(str::trim).filter(|value| !value.is_empty());
+        let role = role.map(str::trim).filter(|value| !value.is_empty());
+        let primary_filter = match (keyword, role) {
+            (Some(keyword), Some(role)) => {
+                if keyword.len() >= role.len() {
+                    keyword
+                } else {
+                    role
+                }
+            }
+            (Some(keyword), None) => keyword,
+            (None, Some(role)) => role,
+            (None, None) => return None,
+        };
+        let preview_filter = keyword.or(role);
+        let secondary_filter = match (keyword, role) {
+            (Some(keyword), Some(role)) if keyword == primary_filter => Some(role),
+            (Some(keyword), Some(role)) if role == primary_filter => Some(keyword),
+            _ => None,
+        };
+        Some(Self {
+            primary_filter,
+            secondary_filter,
+            preview_filter,
+            scope_path,
+            scope_path_prefix: scope_path.and_then(Path::to_str),
+        })
+    }
+}
+
+fn resolved_thread_matches_scope(resolved: &ResolvedThread, scope_path: &Path) -> bool {
+    extract_scope_path_for_provider(resolved.provider, &resolved.path)
+        .as_deref()
+        .is_some_and(|candidate| path_matches_scope(candidate, scope_path))
+}
+
+fn match_candidate_preview_with_index(
+    candidate: &QueryCandidate,
+    keyword: &str,
+    prepared_matches: Option<&PreparedMatches>,
+) -> Result<Option<String>> {
+    let key = SearchIndexKey {
+        provider: candidate.provider,
+        thread_id: candidate.thread_id.clone(),
+    };
+
+    if let Some(prepared_matches) = prepared_matches {
+        if let Some(preview) = prepared_matches.matched_previews.get(&key) {
+            return Ok(Some(preview.clone()));
+        }
+        if prepared_matches.fresh_keys.contains(&key) {
+            return Ok(None);
+        }
+    }
+
+    match_candidate_preview(candidate, keyword)
+}
+
+fn prepare_indexed_matches(
+    search_index: Option<&mut SearchIndex>,
+    candidates: &[QueryCandidate],
+    keyword: Option<&str>,
+) -> Result<Option<PreparedMatches>> {
+    let Some(keyword) = keyword else {
+        return Ok(None);
+    };
+    let Some(search_index) = search_index else {
+        return Ok(None);
+    };
+
+    let rows = candidates
+        .iter()
+        .map(|candidate| SearchIndexCandidate {
+            provider: candidate.provider,
+            thread_id: &candidate.thread_id,
+            source_fingerprint: &candidate.source_fingerprint,
+        })
+        .collect::<Vec<_>>();
+    let prepared = search_index.prepare_matches(&rows, keyword)?;
+    Ok(Some(prepared))
+}
+
+fn build_candidate_search_text(candidate: &QueryCandidate) -> Result<String> {
+    match &candidate.search_target {
+        QuerySearchTarget::File(path) => read_thread_raw(path),
+        QuerySearchTarget::Text(text) => Ok(text.clone()),
+    }
+}
+
+fn extract_scope_path_from_raw(provider: ProviderKind, raw: &str) -> Option<PathBuf> {
+    match provider {
+        ProviderKind::Codex => extract_codex_scope_path_from_raw(raw),
+        _ => None,
+    }
+}
+
 fn match_first_preview_in_file(path: &Path, keyword: &str) -> Result<Option<String>> {
     let mut matcher_builder = RegexMatcherBuilder::new();
     matcher_builder.fixed_strings(true).case_insensitive(true);
@@ -590,7 +1038,7 @@ fn match_first_preview_in_file(path: &Path, keyword: &str) -> Result<Option<Stri
     Ok(preview)
 }
 
-fn match_first_preview_in_text(text: &str, keyword: &str) -> Option<String> {
+pub(crate) fn match_first_preview_in_text(text: &str, keyword: &str) -> Option<String> {
     let matcher = RegexBuilder::new(&regex::escape(keyword))
         .case_insensitive(true)
         .build()
@@ -605,6 +1053,86 @@ fn match_first_preview_in_text(text: &str, keyword: &str) -> Option<String> {
         Some(truncate_preview(text, 160))
     } else {
         Some(truncate_preview(line, 160))
+    }
+}
+
+fn refresh_index_for_provider_session(
+    provider: ProviderKind,
+    roots: &ProviderRoots,
+    session_id: &str,
+) -> Result<()> {
+    let resolved = resolve_thread_for_provider_session(provider, roots, session_id);
+
+    let Ok(resolved) = resolved else {
+        return Ok(());
+    };
+    refresh_resolved_thread_search_index(&resolved)
+}
+
+fn resolve_thread_for_provider_session(
+    provider: ProviderKind,
+    roots: &ProviderRoots,
+    session_id: &str,
+) -> Result<ResolvedThread> {
+    match provider {
+        ProviderKind::Amp => AmpProvider::new(&roots.amp_root).resolve(session_id),
+        ProviderKind::Copilot => CopilotProvider::new(&roots.copilot_root).resolve(session_id),
+        ProviderKind::Codex => CodexProvider::new(&roots.codex_root).resolve(session_id),
+        ProviderKind::Claude => ClaudeProvider::new(&roots.claude_root).resolve(session_id),
+        ProviderKind::Cursor => CursorProvider::new(&roots.cursor_root).resolve(session_id),
+        ProviderKind::Gemini => GeminiProvider::new(&roots.gemini_root).resolve(session_id),
+        ProviderKind::Kimi => KimiProvider::new(&roots.kimi_root).resolve(session_id),
+        ProviderKind::Pi => PiProvider::new(&roots.pi_root).resolve(session_id),
+        ProviderKind::Opencode => OpencodeProvider::new(&roots.opencode_root).resolve(session_id),
+    }
+}
+
+fn refresh_resolved_thread_search_index(resolved: &ResolvedThread) -> Result<()> {
+    let search_text = read_thread_raw(&resolved.path)?;
+    refresh_resolved_thread_search_index_with_raw(resolved, &search_text)
+}
+
+fn refresh_resolved_thread_search_index_with_raw(
+    resolved: &ResolvedThread,
+    search_text: &str,
+) -> Result<()> {
+    let (mut search_index, _) = SearchIndex::open_best_effort();
+    let Some(search_index) = search_index.as_mut() else {
+        return Ok(());
+    };
+
+    let source_fingerprint = file_source_fingerprint(&resolved.path);
+    if search_index.is_fresh(resolved.provider, &resolved.session_id, &source_fingerprint)? {
+        return Ok(());
+    }
+
+    let scope_path = extract_scope_path_for_provider(resolved.provider, &resolved.path);
+    let uri = format!("agents://{}/{}", resolved.provider, resolved.session_id);
+    let thread_source = resolved.path.display().to_string();
+    search_index.replace_document(SearchIndexDocument {
+        provider: resolved.provider,
+        thread_id: &resolved.session_id,
+        uri: &uri,
+        thread_source: &thread_source,
+        scope_path: scope_path.as_ref().and_then(|path| path.to_str()),
+        updated_epoch: file_modified_epoch(&resolved.path),
+        source_fingerprint: &source_fingerprint,
+        search_text,
+    })?;
+    Ok(())
+}
+
+fn extract_scope_path_for_provider(provider: ProviderKind, path: &Path) -> Option<PathBuf> {
+    match provider {
+        ProviderKind::Amp => extract_amp_scope_path(path),
+        ProviderKind::Copilot => extract_copilot_scope_path(path),
+        ProviderKind::Codex => extract_codex_scope_path(path),
+        ProviderKind::Claude => extract_claude_scope_path(path),
+        ProviderKind::Cursor => None,
+        ProviderKind::Gemini => extract_gemini_scope_path(path),
+        ProviderKind::Kimi => None,
+        ProviderKind::Pi => extract_pi_scope_path(path),
+        ProviderKind::Opencode => None,
     }
 }
 
@@ -625,8 +1153,23 @@ fn read_thread_raw(path: &Path) -> Result<String> {
     })
 }
 
+fn file_source_fingerprint(path: &Path) -> String {
+    let Ok(metadata) = fs::metadata(path) else {
+        return "missing".to_string();
+    };
+    let size = metadata.len();
+    let modified_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .map(|value| value.as_nanos())
+        .unwrap_or(0);
+    format!("file:{modified_ns}:{size}")
+}
+
 pub fn render_thread_markdown(uri: &AgentsUri, resolved: &ResolvedThread) -> Result<String> {
     let raw = read_thread_raw(&resolved.path)?;
+    let _ = refresh_resolved_thread_search_index_with_raw(resolved, &raw);
     let markdown = render::render_markdown(uri, &resolved.path, &raw)?;
     Ok(strip_frontmatter(markdown))
 }
@@ -1377,7 +1920,24 @@ fn extract_json_scope_path(
 fn extract_codex_scope_path(path: &Path) -> Option<PathBuf> {
     let file = fs::File::open(path).ok()?;
     let reader = BufReader::new(file);
-    for line in reader.lines().take(QUERY_METADATA_LINE_BUDGET).flatten() {
+    extract_codex_scope_path_from_lines(
+        reader
+            .lines()
+            .take(QUERY_METADATA_LINE_BUDGET)
+            .filter_map(std::result::Result::ok),
+    )
+}
+
+fn extract_codex_scope_path_from_raw(raw: &str) -> Option<PathBuf> {
+    extract_codex_scope_path_from_lines(
+        raw.lines()
+            .map(str::to_string)
+            .take(QUERY_METADATA_LINE_BUDGET),
+    )
+}
+
+fn extract_codex_scope_path_from_lines(lines: impl IntoIterator<Item = String>) -> Option<PathBuf> {
+    for line in lines {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -4782,6 +5342,11 @@ fn collect_codex_query_candidates(
     roots: &ProviderRoots,
     warnings: &mut Vec<String>,
 ) -> Vec<QueryCandidate> {
+    let sqlite_candidates = collect_codex_query_candidates_from_state_db(roots, warnings);
+    if !sqlite_candidates.is_empty() {
+        return sqlite_candidates;
+    }
+
     let mut candidates = Vec::new();
     candidates.extend(collect_simple_file_candidates(
         ProviderKind::Codex,
@@ -4808,6 +5373,172 @@ fn collect_codex_query_candidates(
         warnings,
     ));
     candidates
+}
+
+fn collect_codex_query_candidates_from_state_db(
+    roots: &ProviderRoots,
+    warnings: &mut Vec<String>,
+) -> Vec<QueryCandidate> {
+    let provider = CodexProvider::new(&roots.codex_root);
+    let records = provider.collect_state_thread_records(warnings);
+    if records.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = Vec::new();
+    for record in records {
+        if !record.rollout_path.exists() {
+            continue;
+        }
+        if !is_uuid_session_id(&record.session_id) {
+            warnings.push(format!(
+                "skipped codex sqlite record with invalid thread id={}: {}",
+                record.session_id,
+                record.rollout_path.display()
+            ));
+            continue;
+        }
+        candidates.push(codex_candidate_from_state_record(record));
+    }
+    candidates
+}
+
+fn codex_candidate_from_state_record(record: CodexStateThreadRecord) -> QueryCandidate {
+    let _ = record.archived;
+    let session_id = record.session_id.to_ascii_lowercase();
+    make_file_candidate(
+        ProviderKind::Codex,
+        session_id.clone(),
+        format!("agents://codex/{session_id}"),
+        record.rollout_path.clone(),
+        extract_codex_scope_path(&record.rollout_path),
+    )
+}
+
+fn collect_codex_index_candidates(
+    roots: &ProviderRoots,
+    warnings: &mut Vec<String>,
+    search_index: &mut SearchIndex,
+) -> Result<Vec<QueryCandidate>> {
+    let sqlite_candidates =
+        collect_codex_index_candidates_from_state_db(roots, warnings, search_index)?;
+    if !sqlite_candidates.is_empty() {
+        return Ok(sqlite_candidates);
+    }
+
+    let mut candidates = Vec::new();
+    candidates.extend(collect_simple_file_candidates(
+        ProviderKind::Codex,
+        &roots.codex_root.join("sessions"),
+        |path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+        },
+        extract_codex_rollout_id,
+        |_| None,
+        warnings,
+    ));
+    candidates.extend(collect_simple_file_candidates(
+        ProviderKind::Codex,
+        &roots.codex_root.join("archived_sessions"),
+        |path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+        },
+        extract_codex_rollout_id,
+        |_| None,
+        warnings,
+    ));
+    Ok(candidates)
+}
+
+fn collect_codex_index_candidates_from_state_db(
+    roots: &ProviderRoots,
+    warnings: &mut Vec<String>,
+    search_index: &mut SearchIndex,
+) -> Result<Vec<QueryCandidate>> {
+    let provider = CodexProvider::new(&roots.codex_root);
+    let watermark = provider.state_manifest_watermark(warnings);
+    if let Some(watermark) = watermark.as_deref() {
+        if let Some(entries) =
+            search_index.load_provider_manifest(ProviderKind::Codex, watermark)?
+        {
+            return Ok(entries
+                .into_iter()
+                .filter_map(codex_candidate_from_manifest_entry)
+                .collect());
+        }
+    }
+
+    let records = provider.collect_state_thread_records(warnings);
+    if records.is_empty() {
+        if let Some(watermark) = watermark.as_deref() {
+            search_index.replace_provider_manifest(ProviderKind::Codex, watermark, &[])?;
+        }
+        return Ok(Vec::new());
+    }
+
+    let mut manifest_entries = Vec::new();
+    let mut candidates = Vec::new();
+    for record in records {
+        if let Some(entry) = codex_manifest_entry_from_state_record(record, warnings) {
+            if let Some(candidate) = codex_candidate_from_manifest_entry(entry.clone()) {
+                candidates.push(candidate);
+            }
+            manifest_entries.push(entry);
+        }
+    }
+    if let Some(watermark) = watermark.as_deref() {
+        search_index.replace_provider_manifest(
+            ProviderKind::Codex,
+            watermark,
+            &manifest_entries,
+        )?;
+    }
+    Ok(candidates)
+}
+
+fn codex_manifest_entry_from_state_record(
+    record: CodexStateThreadRecord,
+    warnings: &mut Vec<String>,
+) -> Option<ProviderManifestEntry> {
+    let _ = record.archived;
+    if !record.rollout_path.exists() {
+        return None;
+    }
+    if !is_uuid_session_id(&record.session_id) {
+        warnings.push(format!(
+            "skipped codex sqlite record with invalid thread id={}: {}",
+            record.session_id,
+            record.rollout_path.display()
+        ));
+        return None;
+    }
+    let thread_id = record.session_id.to_ascii_lowercase();
+    Some(ProviderManifestEntry {
+        provider: ProviderKind::Codex,
+        thread_id: thread_id.clone(),
+        uri: format!("agents://codex/{thread_id}"),
+        thread_source: record.rollout_path.display().to_string(),
+        scope_path: extract_codex_scope_path(&record.rollout_path)
+            .and_then(|path| path.to_str().map(ToString::to_string)),
+    })
+}
+
+fn codex_candidate_from_manifest_entry(entry: ProviderManifestEntry) -> Option<QueryCandidate> {
+    let path = PathBuf::from(&entry.thread_source);
+    if !path.exists() {
+        return None;
+    }
+    Some(make_file_candidate(
+        entry.provider,
+        entry.thread_id.clone(),
+        entry.uri,
+        path,
+        entry.scope_path.map(PathBuf::from),
+    ))
 }
 
 fn collect_claude_query_candidates(
@@ -4927,6 +5658,7 @@ fn collect_cursor_query_candidates(
             thread_source: path.display().to_string(),
             updated_at: modified_timestamp_string(&path),
             updated_epoch: file_modified_epoch(&path),
+            source_fingerprint: file_source_fingerprint(&path),
             scope_path: materialized
                 .metadata
                 .workspace_path
@@ -5171,6 +5903,7 @@ fn collect_opencode_query_candidates(
             thread_source: format!("{}#session:{session_id}", db_path.display()),
             updated_at: updated_epoch.map(|value| value.to_string()),
             updated_epoch,
+            source_fingerprint: format!("opencode-session:{}", updated_epoch.unwrap_or(0)),
             scope_path: directory.as_deref().and_then(scope_path_from_str),
             search_target,
         });
@@ -5302,6 +6035,7 @@ fn make_file_candidate(
         thread_source: path.display().to_string(),
         updated_at: modified_timestamp_string(&path),
         updated_epoch: file_modified_epoch(&path),
+        source_fingerprint: file_source_fingerprint(&path),
         scope_path,
         search_target: QuerySearchTarget::File(path),
     }


### PR DESCRIPTION
This PR turns xurl's query acceleration into a layered local cache with provider discovery manifests, thread materialization reuse, and an internal FTS-backed search index maintained by the hidden `xurl -X index` worker. It keeps correctness on the direct-scan path while letting repeated searches and rebuilds stay fully local and disposable.

The change also adds a repository benchmark at `xurl-core/benches/search_index.rs` so we can track regressions in cold query, warm query, incremental refresh, full build, and FTS rebuild. On the current synthetic `codex` benchmark (`2500` threads, `3` samples), warm query is about `9.6ms`, incremental refresh about `451ms`, full build about `647ms`, and FTS rebuild about `556ms`.
